### PR TITLE
fix: invalid params restriction

### DIFF
--- a/deploy/src/bin/neutron_initialization.rs
+++ b/deploy/src/bin/neutron_initialization.rs
@@ -126,11 +126,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         "new_config".to_string(),
                         "denom_to_pfm_map".to_string(),
                     ]),
-                    ParamRestriction::CannotBeIncluded(vec![
-                        "update_config".to_string(),
-                        "new_config".to_string(),
-                        "eureka_config".to_string(),
-                    ]),
                 ]),
             },
         },
@@ -145,8 +140,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             message_type: MessageType::CosmwasmExecuteMsg,
             message: Message {
                 name: "process_function".to_string(),
-                // Only Transfer can be called because Eureka will fail as there is no config, no need for restrictions
-                params_restrictions: None,
+                // Only allow calling transfer
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "transfer".to_string(),
+                ])]),
             },
         },
         contract_address: LibraryAccountType::Addr(ntrn_strategy_config.libraries.ica_transfer),


### PR DESCRIPTION
OptionUpdate serializes as "none" so instead of checking that it's not present when updating, we skip that restriction and verify that only "transfer" is executed, which ignores Eureka config anyways.

We could alternatively have checked with MustBeValue: "none" instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted parameter restrictions for certain functions, allowing more flexibility for configuration updates and enforcing stricter requirements for transfer operations. No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->