### PR TITLE
wbtc deployment scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8910,6 +8910,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wbtc_deploy"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "bincode",
+ "cosmrs",
+ "cosmwasm-std",
+ "dotenv",
+ "hex",
+ "packages",
+ "serde",
+ "sp1-sdk",
+ "tokio",
+ "toml",
+ "valence-account-utils",
+ "valence-authorization-utils",
+ "valence-clearing-queue-supervaults",
+ "valence-domain-clients",
+ "valence-dynamic-ratio-query-provider",
+ "valence-forwarder-library",
+ "valence-ica-ibc-transfer",
+ "valence-library-utils",
+ "valence-mars-lending",
+ "valence-maxbtc-issuer",
+ "valence-processor-utils",
+ "valence-splitter-library",
+ "valence-supervaults-lper",
+ "valence-supervaults-withdrawer",
+ "valence-verification-gateway",
+ "wbtc_types",
+]
+
+[[package]]
 name = "wbtc_test_deploy"
 version = "0.1.0"
 dependencies = [
@@ -8978,6 +9012,16 @@ dependencies = [
 
 [[package]]
 name = "wbtc_test_types"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "cosmwasm-std",
+ "serde",
+ "valence-strategist-utils",
+]
+
+[[package]]
+name = "wbtc_types"
 version = "0.1.0"
 dependencies = [
  "alloy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,9 @@ members = [
     "packages",
     "strategies/wbtc_test/deploy",
     "strategies/wbtc_test/strategist",
-    "strategies/wbtc_test/types"
+    "strategies/wbtc_test/types",
+    "strategies/wbtc/deploy",
+    "strategies/wbtc/types"
 ]
 resolver = "2"
 

--- a/strategies/wbtc/deploy/Cargo.toml
+++ b/strategies/wbtc/deploy/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name    = "wbtc_deploy"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+wbtc_types                           = { path = "../types" }
+packages                             = { path = "../../../packages" }
+anyhow                               = { workspace = true }
+toml                                 = { workspace = true }
+serde                                = { workspace = true }
+cosmwasm-std                         = { workspace = true }
+cosmrs                               = { workspace = true }
+dotenv                               = { workspace = true }
+tokio                                = { workspace = true }
+valence-domain-clients               = { workspace = true }
+alloy                                = { workspace = true }
+hex                                  = { workspace = true }
+valence-authorization-utils          = { workspace = true }
+valence-processor-utils              = { workspace = true }
+valence-library-utils                = { workspace = true }
+valence-account-utils                = { workspace = true }
+valence-ica-ibc-transfer             = { workspace = true }
+valence-mars-lending                 = { workspace = true }
+valence-supervaults-lper             = { workspace = true }
+valence-supervaults-withdrawer       = { workspace = true }
+valence-splitter-library             = { workspace = true }
+valence-forwarder-library            = { workspace = true }
+valence-clearing-queue-supervaults   = { workspace = true }
+valence-dynamic-ratio-query-provider = { workspace = true }
+valence-verification-gateway         = { workspace = true }
+valence-maxbtc-issuer                = { workspace = true }
+sp1-sdk                              = { workspace = true }
+bincode                              = { workspace = true }

--- a/strategies/wbtc/deploy/README.md
+++ b/strategies/wbtc/deploy/README.md
@@ -1,6 +1,6 @@
 # Deploy instructions
 
-1. If the wasm blobs are not uploaded, run the `neutron_upload.rs` script which will upload all contracts in /packages/src/contracts/cw and output the code ids in `neutron_code_ids.toml`. These file will be used to instantiate the file.
+1. If the wasm blobs are not uploaded, run the `neutron_upload.rs` script which will upload all contracts in /packages/src/contracts/cw and output the code ids in `neutron_code_ids.toml`. This file will be used to instantiate the contracts.
 
 2. Fill in all the information in `neutron.toml` except the coprocessor app fields at the end and run the `neutron_deploy.rs` script which will instantiate all the contracts, trigger the ICA creation and output all relevant addresses in `neutron_strategy_config.toml` and `gaia_strategy_config.toml` which will be used by the strategist.
 
@@ -14,4 +14,6 @@
 
 ### Notes for Strategist
 
-This vault involves updating all the supervaults LPers configuration for the 2nd phase (maxBTC migration). Therefore, once the migration is completed, the corresponding LP denoms of the supervaults need to be updated because they will be different.
+This vault involves updating all the supervaults LPers configuration for the 2nd phase (maxBTC migration). Therefore, once the migration is completed, the corresponding LP denoms of the supervaults need to be updated because they will be different as we are using different supervaults.
+So, before relayer is restarted after the phase migration, the corresponding strategy_config files need to be updated with the right parameters.
+

--- a/strategies/wbtc/deploy/README.md
+++ b/strategies/wbtc/deploy/README.md
@@ -1,0 +1,17 @@
+# Deploy instructions
+
+1. If the wasm blobs are not uploaded, run the `neutron_upload.rs` script which will upload all contracts in /packages/src/contracts/cw and output the code ids in `neutron_code_ids.toml`. These file will be used to instantiate the file.
+
+2. Fill in all the information in `neutron.toml` except the coprocessor app fields at the end and run the `neutron_deploy.rs` script which will instantiate all the contracts, trigger the ICA creation and output all relevant addresses in `neutron_strategy_config.toml` and `gaia_strategy_config.toml` which will be used by the strategist.
+
+3. Now that we have deployed on Neutron and we have all relevant addresses in `neutron_strategy_config.toml` and `gaia_strategy_config.toml` we can deploy on Ethereum. For that, input the generated ICA in `ethereum.toml` and run the `ethereum_deploy.rs` script.
+
+4. Now that we have deployed on both Ethereum and Neutron we can finalize the coprocessor apps and get their relevant IDs.
+
+5. Run `neutron_initialization.rs` which will create all the authorizations including the ZK authorization.
+
+6. Run `ethereum_initialization.rs` which will create the relevant IBC Eureka ZK Authorization on the authorization contract that the strategist can execute.
+
+### Notes for Strategist
+
+This vault involves updating all the supervaults LPers configuration for the 2nd phase (maxBTC migration). Therefore, once the migration is completed, the corresponding LP denoms of the supervaults need to be updated because they will be different.

--- a/strategies/wbtc/deploy/src/bin/ethereum_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/ethereum_deploy.rs
@@ -237,6 +237,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     sol!(
         struct IBCEurekaTransferConfig {
             uint256 amount;
+            uint256 minAmountOut;
             address transferToken;
             address inputAccount;
             string recipient;
@@ -247,7 +248,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     let eureka_transfer_config = IBCEurekaTransferConfig {
-        amount: U256::ZERO, // Full amount
+        amount: U256::ZERO,       // Full amount
+        minAmountOut: U256::ZERO, // No minimum amount out
         transferToken: parameters.vault.deposit_token,
         inputAccount: deposit_account,
         recipient: parameters.eureka_transfer.recipient,

--- a/strategies/wbtc/deploy/src/bin/ethereum_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/ethereum_deploy.rs
@@ -1,0 +1,338 @@
+use std::{env, error::Error, fs};
+
+use alloy::{
+    hex::FromHex,
+    primitives::{Address, Bytes, FixedBytes, U256},
+    sol,
+    sol_types::SolValue,
+};
+use cosmwasm_std::Uint128;
+use packages::types::sol_types::{
+    Authorization, BaseAccount, ERC1967Proxy, IBCEurekaTransfer,
+    OneWayVault::{self, FeeDistributionConfig, OneWayVaultConfig},
+    SP1VerificationGateway,
+    processor_contract::LiteProcessor,
+};
+use serde::Deserialize;
+use sp1_sdk::{HashableKey, SP1VerifyingKey};
+use valence_domain_clients::{
+    clients::{coprocessor::CoprocessorClient, ethereum::EthereumClient},
+    coprocessor::base_client::CoprocessorBaseClient,
+    evm::{base_client::EvmBaseClient, request_provider_client::RequestProviderClient},
+};
+use wbtc_deploy::{DIR, SP1_VERIFIER};
+use wbtc_types::ethereum_config::{
+    EthereumAccounts, EthereumCoprocessorAppIds, EthereumDenoms, EthereumLibraries,
+    EthereumStrategyConfig,
+};
+
+#[derive(Deserialize, Debug)]
+struct Parameters {
+    general: General,
+    vault: Vault,
+    eureka_transfer: EurekaTransfer,
+    coprocessor_app: CoprocessorApp,
+}
+
+#[derive(Deserialize, Debug)]
+struct General {
+    rpc_url: String,
+    owner: Address,
+    valence_owner: Address,
+    coprocessor_root: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Vault {
+    deposit_token: Address,
+    strategist: Address,
+    platform_fee_account: Address,
+    strategist_fee_account: Address,
+    strategist_fee_ratio_bps: u32,
+    scaling_factor: Uint128,
+    deposit_cap: U256,
+    deposit_fee_bps: u32,
+    withdraw_rate_bps: u32,
+    starting_rate: U256,
+    max_rate_update_delay: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct EurekaTransfer {
+    handler: Address,
+    recipient: String,
+    source_client: String,
+    timeout: u64,
+    ibc_transfer_threshold_amt: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct CoprocessorApp {
+    eureka_transfer_coprocessor_app_id: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    dotenv::dotenv().ok();
+    let mnemonic = env::var("MNEMONIC").expect("mnemonic must be provided");
+
+    // Read ethereum.toml from the deploy directory
+    let current_dir = env::current_dir()?;
+    let parameters = fs::read_to_string(current_dir.join(format!("{DIR}/ethereum.toml")))
+        .expect("Failed to read file");
+
+    // Parse the TOML into your struct
+    let parameters: Parameters = toml::from_str(&parameters).expect("Failed to parse TOML");
+
+    let eth_client = EthereumClient::new(&parameters.general.rpc_url, &mnemonic, None)?;
+    let my_address = eth_client.signer().address();
+    let rp = eth_client.get_request_provider().await?;
+
+    let deposit_account_tx =
+        BaseAccount::deploy_builder(&rp, my_address, vec![]).into_transaction_request();
+
+    let deposit_account = eth_client
+        .sign_and_send(deposit_account_tx)
+        .await?
+        .contract_address
+        .unwrap();
+    println!("Deposit account deployed at: {}", deposit_account);
+
+    let fee_distribution_config = FeeDistributionConfig {
+        strategistAccount: parameters.vault.strategist_fee_account,
+        platformAccount: parameters.vault.platform_fee_account,
+        strategistRatioBps: parameters.vault.strategist_fee_ratio_bps,
+    };
+
+    let one_way_vault_config = OneWayVaultConfig {
+        depositAccount: deposit_account,
+        strategist: parameters.vault.strategist,
+        depositFeeBps: parameters.vault.deposit_fee_bps,
+        withdrawRateBps: parameters.vault.withdraw_rate_bps,
+        maxRateUpdateDelay: parameters.vault.max_rate_update_delay,
+        depositCap: parameters.vault.deposit_cap,
+        feeDistribution: fee_distribution_config,
+    };
+
+    let implementation_tx = OneWayVault::deploy_builder(&rp).into_transaction_request();
+
+    let implementation = eth_client
+        .sign_and_send(implementation_tx)
+        .await?
+        .contract_address
+        .unwrap();
+
+    let proxy_tx =
+        ERC1967Proxy::deploy_builder(&rp, implementation, Bytes::new()).into_transaction_request();
+
+    let proxy = eth_client
+        .sign_and_send(proxy_tx)
+        .await?
+        .contract_address
+        .unwrap();
+
+    println!("Vault deployed at: {proxy}");
+
+    let vault = OneWayVault::new(proxy, &rp);
+
+    let initialize_tx = vault
+        .initialize(
+            parameters.general.owner,
+            one_way_vault_config.abi_encode().into(),
+            parameters.vault.deposit_token,
+            "Neutron-XChain-Vault".to_string(), // vault token name
+            "nVault".to_string(),               // vault token symbol
+            parameters.vault.starting_rate,
+        )
+        .into_transaction_request();
+    eth_client.sign_and_send(initialize_tx).await?;
+    println!("Vault initialized");
+
+    let processor =
+        LiteProcessor::deploy_builder(&rp, FixedBytes::<32>::default(), Address::ZERO, 0, vec![])
+            .into_transaction_request();
+
+    let processor_address = eth_client
+        .sign_and_send(processor)
+        .await?
+        .contract_address
+        .unwrap();
+    println!("Processor deployed at: {processor_address}");
+
+    // TODO: If wee already deployed it we don't need to deploy it again, we reuse the first one deployed
+    let verification_gateway =
+        SP1VerificationGateway::deploy_builder(&rp).into_transaction_request();
+    let verification_gateway_implementation = eth_client
+        .sign_and_send(verification_gateway)
+        .await?
+        .contract_address
+        .unwrap();
+
+    let proxy_tx =
+        ERC1967Proxy::deploy_builder(&rp, verification_gateway_implementation, Bytes::new())
+            .into_transaction_request();
+    let verification_gateway_address = eth_client
+        .sign_and_send(proxy_tx)
+        .await?
+        .contract_address
+        .unwrap();
+    println!("Verification Gateway deployed at: {verification_gateway_address}");
+
+    // Initialize the verification gateway
+    // We need to get the domain vk of the coprocessor
+    let coprocessor_client = CoprocessorClient::default();
+    let domain_vk = coprocessor_client.get_domain_vk().await?;
+    let sp1_domain_vk: SP1VerifyingKey = bincode::deserialize(&domain_vk)?;
+    let domain_vk = FixedBytes::<32>::from_hex(sp1_domain_vk.bytes32()).unwrap();
+
+    let verification_gateway = SP1VerificationGateway::new(verification_gateway_address, &rp);
+    let initialize_verification_gateway_tx = verification_gateway
+        .initialize(
+            parameters.general.coprocessor_root.parse().unwrap(),
+            SP1_VERIFIER.parse().unwrap(),
+            domain_vk,
+        )
+        .into_transaction_request();
+    eth_client
+        .sign_and_send(initialize_verification_gateway_tx)
+        .await?;
+    println!("Verification Gateway initialized");
+
+    // Transfer the ownership of the verification gateway
+    let transfer_ownership_tx = verification_gateway
+        .transferOwnership(parameters.general.valence_owner)
+        .into_transaction_request();
+    eth_client.sign_and_send(transfer_ownership_tx).await?;
+    println!(
+        "Verification Gateway ownership transferred to: {}",
+        parameters.general.valence_owner
+    );
+
+    let authorization = Authorization::deploy_builder(
+        &rp,
+        my_address, // We will be initial owners to eventually add the authorizations, then we need to transfer ownership
+        processor_address,
+        verification_gateway_address,
+        true, // Store callbacks
+    );
+
+    let authorization = eth_client
+        .sign_and_send(authorization.into_transaction_request())
+        .await?
+        .contract_address
+        .unwrap();
+    println!("Authorization deployed at: {authorization}");
+
+    // Add authorization contract as an authorized address to the proccessor
+    let processor = LiteProcessor::new(processor_address, &rp);
+
+    let add_authorization_tx = processor
+        .addAuthorizedAddress(authorization)
+        .into_transaction_request();
+
+    eth_client.sign_and_send(add_authorization_tx).await?;
+    println!("Authorization added to processor");
+
+    // Deploy Eureka Transfer
+    sol!(
+        struct IBCEurekaTransferConfig {
+            uint256 amount;
+            address transferToken;
+            address inputAccount;
+            string recipient;
+            string sourceClient;
+            uint64 timeout;
+            address eurekaHandler;
+        }
+    );
+
+    let eureka_transfer_config = IBCEurekaTransferConfig {
+        amount: U256::ZERO, // Full amount
+        transferToken: parameters.vault.deposit_token,
+        inputAccount: deposit_account,
+        recipient: parameters.eureka_transfer.recipient,
+        sourceClient: parameters.eureka_transfer.source_client,
+        timeout: parameters.eureka_transfer.timeout,
+        eurekaHandler: parameters.eureka_transfer.handler,
+    };
+
+    let eureka_transfer = IBCEurekaTransfer::deploy_builder(
+        &rp,
+        parameters.general.owner,
+        processor_address,
+        eureka_transfer_config.abi_encode().into(),
+    );
+
+    let eureka_transfer = eth_client
+        .sign_and_send(eureka_transfer.into_transaction_request())
+        .await?
+        .contract_address
+        .unwrap();
+    println!("Eureka Transfer deployed at: {eureka_transfer}");
+
+    // Approve this library from the deposit account
+    let base_account = BaseAccount::new(deposit_account, &rp);
+    let approve_library_tx = base_account
+        .approveLibrary(eureka_transfer)
+        .into_transaction_request();
+    eth_client.sign_and_send(approve_library_tx).await?;
+    println!("Eureka Transfer library approved from deposit account");
+
+    // Transfer ownership of the deposit account to the owner
+    let transfer_ownership_tx = base_account
+        .transferOwnership(parameters.general.owner)
+        .into_transaction_request();
+    eth_client.sign_and_send(transfer_ownership_tx).await?;
+
+    // Query to verify the ownership was transferred
+    let new_owner = base_account.owner().call().await?._0;
+    println!("Deposit account ownership transferred to: {new_owner}");
+    assert_eq!(new_owner, parameters.general.owner);
+
+    // Create the Ethereum Strategy Config
+    let denoms = EthereumDenoms {
+        deposit_token: parameters.vault.deposit_token,
+    };
+
+    let accounts = EthereumAccounts {
+        deposit: deposit_account,
+    };
+
+    let libraries = EthereumLibraries {
+        one_way_vault: proxy,
+        eureka_transfer,
+    };
+
+    let coprocessor_app_ids = EthereumCoprocessorAppIds {
+        ibc_eureka: parameters
+            .coprocessor_app
+            .eureka_transfer_coprocessor_app_id,
+    };
+
+    let eth_cfg = EthereumStrategyConfig {
+        ibc_transfer_threshold_amt: U256::from(
+            parameters.eureka_transfer.ibc_transfer_threshold_amt,
+        ),
+        rate_scaling_factor: parameters.vault.scaling_factor,
+        rpc_url: parameters.general.rpc_url,
+        authorizations: authorization,
+        processor: processor_address,
+        denoms,
+        accounts,
+        libraries,
+        coprocessor_app_ids,
+    };
+
+    println!("Ethereum Strategy Config created successfully");
+
+    // Save the Ethereum Strategy Config to a toml file
+    let eth_cfg_toml =
+        toml::to_string(&eth_cfg).expect("Failed to serialize Ethereum Strategy Config");
+    fs::write(
+        current_dir.join(format!("{DIR}/ethereum_strategy_config.toml")),
+        eth_cfg_toml,
+    )
+    .expect("Failed to write Ethereum Strategy Config to file");
+
+    Ok(())
+}

--- a/strategies/wbtc/deploy/src/bin/ethereum_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/ethereum_deploy.rs
@@ -159,7 +159,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
     println!("Processor deployed at: {processor_address}");
 
-    // TODO: If wee already deployed it we don't need to deploy it again, we reuse the first one deployed
+    // TODO: If we already deployed it we don't need to deploy it again, we reuse the first one deployed
     let verification_gateway =
         SP1VerificationGateway::deploy_builder(&rp).into_transaction_request();
     let verification_gateway_implementation = eth_client

--- a/strategies/wbtc/deploy/src/bin/ethereum_initialization.rs
+++ b/strategies/wbtc/deploy/src/bin/ethereum_initialization.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     eth_client.sign_and_send(tx).await?;
     println!("Authorization created successfully");
 
-    // TODO: Keep the ownership fo the authorization contract for now but we should transfer it eventually
+    // TODO: Keep the ownership of the authorization contract for now but we should transfer it eventually
 
     Ok(())
 }

--- a/strategies/wbtc/deploy/src/bin/ethereum_initialization.rs
+++ b/strategies/wbtc/deploy/src/bin/ethereum_initialization.rs
@@ -1,0 +1,91 @@
+use std::{env, error::Error, fs};
+
+use alloy::{
+    hex::FromHex,
+    primitives::{Address, FixedBytes},
+};
+use packages::types::sol_types::Authorization;
+use serde::Deserialize;
+use sp1_sdk::{HashableKey, SP1VerifyingKey};
+use valence_domain_clients::{
+    clients::{coprocessor::CoprocessorClient, ethereum::EthereumClient},
+    coprocessor::base_client::CoprocessorBaseClient,
+    evm::{base_client::EvmBaseClient, request_provider_client::RequestProviderClient},
+};
+use wbtc_deploy::DIR;
+use wbtc_types::ethereum_config::EthereumStrategyConfig;
+
+#[derive(Deserialize, Debug)]
+struct Parameters {
+    general: General,
+    vault: Vault,
+    coprocessor_app: CoprocessorApp,
+}
+
+#[derive(Deserialize, Debug)]
+struct General {
+    rpc_url: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Vault {
+    strategist: Address,
+}
+
+#[derive(Deserialize, Debug)]
+struct CoprocessorApp {
+    eureka_transfer_coprocessor_app_id: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    dotenv::dotenv().ok();
+    let mnemonic = env::var("MNEMONIC").expect("mnemonic must be provided");
+
+    // Read ethereum.toml from the deploy directory
+    let current_dir = env::current_dir()?;
+    let parameters = fs::read_to_string(current_dir.join(format!("{DIR}/ethereum.toml")))
+        .expect("Failed to read file");
+    let parameters: Parameters = toml::from_str(&parameters).expect("Failed to parse TOML");
+
+    let eth_stg_cfg =
+        fs::read_to_string(current_dir.join(format!("{DIR}/ethereum_strategy_config.toml")))
+            .expect("Failed to read file");
+
+    let eth_stg_cfg: EthereumStrategyConfig =
+        toml::from_str(&eth_stg_cfg).expect("Failed to parse TOML");
+
+    let eth_client = EthereumClient::new(&parameters.general.rpc_url, &mnemonic, None)?;
+    let rp = eth_client.get_request_provider().await?;
+
+    let authorization = Authorization::new(eth_stg_cfg.authorizations, &rp);
+
+    // Get the VK for the coprocessor app
+    let coprocessor_client = CoprocessorClient::default();
+    let program_vk = coprocessor_client
+        .get_vk(
+            &parameters
+                .coprocessor_app
+                .eureka_transfer_coprocessor_app_id,
+        )
+        .await?;
+
+    let sp1_program_vk: SP1VerifyingKey = bincode::deserialize(&program_vk)?;
+    let program_vk = FixedBytes::<32>::from_hex(sp1_program_vk.bytes32()).unwrap();
+    let registries = vec![0]; // Only one and IBC Eureka app will use registry 0
+    let authorized_addresses = vec![parameters.vault.strategist];
+    let vks = vec![program_vk];
+
+    // Remember we send arrays because we allow  multiple registries added at once
+    let tx = authorization
+        .addRegistries(registries, vec![authorized_addresses], vks, vec![false])
+        .into_transaction_request();
+
+    // Send the transaction
+    eth_client.sign_and_send(tx).await?;
+    println!("Authorization created successfully");
+
+    // TODO: Keep the ownership fo the authorization contract for now but we should transfer it eventually
+
+    Ok(())
+}

--- a/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
@@ -86,10 +86,10 @@ struct Program {
     pumpbtc_supervault_asset1: String,
     pumpbtc_supervault_asset2: String,
     pumpbtc_supervault_lp_denom: String,
-    bedrock_supervault: String,
-    bedrock_supervault_asset1: String,
-    bedrock_supervault_asset2: String,
-    bedrock_supervault_lp_denom: String,
+    bedrockbtc_supervault: String,
+    bedrockbtc_supervault_asset1: String,
+    bedrockbtc_supervault_asset2: String,
+    bedrockbtc_supervault_lp_denom: String,
     initial_split_mars_ratio: String,
     initial_split_fbtc_ratio: String,
     initial_split_lbtc_ratio: String,
@@ -103,7 +103,7 @@ struct Program {
     solvbtc_settlement_ratio_percentage: u64,
     ebtc_settlement_ratio_percentage: u64,
     pumpbtc_settlement_ratio_percentage: u64,
-    bedrock_settlement_ratio_percentage: u64,
+    bedrockbtc_settlement_ratio_percentage: u64,
     fbtc_denom: String,
     lbtc_denom: String,
     solvbtc_denom: String,
@@ -358,7 +358,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Decimal::from_str(&params.program.initial_split_pumpbtc_ratio).unwrap(),
         ),
         (
-            predicted_base_accounts[7].clone(), // Bedrock WBTC supervault deposit account
+            predicted_base_accounts[7].clone(), // bedrockbtc WBTC supervault deposit account
             Decimal::from_str(&params.program.initial_split_bedrockbtc_ratio).unwrap(),
         ),
     ]);
@@ -458,7 +458,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 denom: UncheckedDenom::Native(
                     params.program.deposit_token_on_neutron_denom.clone(),
                 ),
-                account: LibraryAccountType::Addr(predicted_base_accounts[7].clone()), // Bedrock WBTC supervault deposit account
+                account: LibraryAccountType::Addr(predicted_base_accounts[7].clone()), // bedrockbtc WBTC supervault deposit account
                 amount: UncheckedSplitAmount::DynamicRatio {
                     contract_addr: dynamic_ratio_query_provider_address.clone(),
                     params: predicted_base_accounts[7].clone(),
@@ -686,36 +686,36 @@ async fn main() -> Result<(), Box<dyn Error>> {
         pumpbtc_supervaults_lper_library_address
     );
 
-    let bedrock_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+    let bedrockbtc_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
         input_addr: LibraryAccountType::Addr(predicted_base_accounts[7].clone()),
         output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
-        vault_addr: params.program.bedrock_supervault.clone(),
+        vault_addr: params.program.bedrockbtc_supervault.clone(),
         lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
             asset_data: valence_library_utils::liquidity_utils::AssetData {
-                asset1: params.program.bedrock_supervault_asset1.clone(),
-                asset2: params.program.bedrock_supervault_asset2.clone(),
+                asset1: params.program.bedrockbtc_supervault_asset1.clone(),
+                asset2: params.program.bedrockbtc_supervault_asset2.clone(),
             },
-            lp_denom: params.program.bedrock_supervault_lp_denom.clone(),
+            lp_denom: params.program.bedrockbtc_supervault_lp_denom.clone(),
         },
     };
-    let instantiate_bedrock_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+    let instantiate_bedrockbtc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
         valence_supervaults_lper::msg::LibraryConfig,
     > {
         owner: processor_address.clone(),
         processor: processor_address.clone(),
-        config: bedrock_supervaults_lper_config,
+        config: bedrockbtc_supervaults_lper_config,
     };
-    let bedrock_supervaults_lper_library_address = neutron_client
+    let bedrockbtc_supervaults_lper_library_address = neutron_client
         .instantiate(
             code_id_supervaults_lper,
-            "bedrock_supervault_lper".to_string(),
-            instantiate_bedrock_supervaults_lper_msg,
+            "bedrockbtc_supervault_lper".to_string(),
+            instantiate_bedrockbtc_supervaults_lper_msg,
             None,
         )
         .await?;
     println!(
-        "Bedrock-WBTC Supervaults lper library instantiated: {}",
-        bedrock_supervaults_lper_library_address
+        "bedrockbtc-WBTC Supervaults lper library instantiated: {}",
+        bedrockbtc_supervaults_lper_library_address
     );
 
     // We'll also instantiate the maxBTC-BTC one even though we don't have the address yet,
@@ -791,10 +791,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 ),
             },
             SupervaultSettlementInfo {
-                supervault_addr: params.program.bedrock_supervault.clone(),
+                supervault_addr: params.program.bedrockbtc_supervault.clone(),
                 supervault_sender: predicted_base_accounts[7].clone(),
                 settlement_ratio: Decimal::percent(
-                    params.program.bedrock_settlement_ratio_percentage,
+                    params.program.bedrockbtc_settlement_ratio_percentage,
                 ),
             },
         ],
@@ -991,37 +991,38 @@ async fn main() -> Result<(), Box<dyn Error>> {
         pumpbtc_supervault_withdrawer_library_address
     );
 
-    let bedrock_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
-        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
-        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
-        vault_addr: params.program.bedrock_supervault.clone(),
-        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
-            asset_data: valence_library_utils::liquidity_utils::AssetData {
-                asset1: params.program.bedrock_supervault_asset1.clone(),
-                asset2: params.program.bedrock_supervault_asset2.clone(),
+    let bedrockbtc_supervault_withdrawer_config =
+        valence_supervaults_withdrawer::msg::LibraryConfig {
+            input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+            output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+            vault_addr: params.program.bedrockbtc_supervault.clone(),
+            lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+                asset_data: valence_library_utils::liquidity_utils::AssetData {
+                    asset1: params.program.bedrockbtc_supervault_asset1.clone(),
+                    asset2: params.program.bedrockbtc_supervault_asset2.clone(),
+                },
+                lp_denom: params.program.bedrockbtc_supervault_lp_denom.clone(),
             },
-            lp_denom: params.program.bedrock_supervault_lp_denom.clone(),
-        },
-    };
-    let instantiate_bedrock_supervaults_withdrawer_msg =
+        };
+    let instantiate_bedrockbtc_supervaults_withdrawer_msg =
         valence_library_utils::msg::InstantiateMsg::<
             valence_supervaults_withdrawer::msg::LibraryConfig,
         > {
             owner: processor_address.clone(),
             processor: processor_address.clone(),
-            config: bedrock_supervault_withdrawer_config,
+            config: bedrockbtc_supervault_withdrawer_config,
         };
-    let bedrock_supervault_withdrawer_library_address = neutron_client
+    let bedrockbtc_supervault_withdrawer_library_address = neutron_client
         .instantiate(
             code_id_supervaults_withdrawer,
-            "bedrock_supervault_withdrawer".to_string(),
-            instantiate_bedrock_supervaults_withdrawer_msg,
+            "bedrockbtc_supervault_withdrawer".to_string(),
+            instantiate_bedrockbtc_supervaults_withdrawer_msg,
             None,
         )
         .await?;
     println!(
-        "Bedrock-WBTC Supervaults withdrawer library instantiated: {}",
-        bedrock_supervault_withdrawer_library_address
+        "bedrockbtc-WBTC Supervaults withdrawer library instantiated: {}",
+        bedrockbtc_supervault_withdrawer_library_address
     );
 
     // 2. Instantiate the maxbtc issuer that will issue the maxbtc token depositing the counterparty of the deposit token in the vault.
@@ -1089,8 +1090,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             },
             UncheckedSplitConfig {
                 denom: UncheckedDenom::Native(params.program.bedrockbtc_denom.clone()),
-                account: LibraryAccountType::Addr(predicted_base_accounts[7].clone()), // BedrockBTC deposit account
-                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of Bedrock
+                account: LibraryAccountType::Addr(predicted_base_accounts[7].clone()), // bedrockbtc deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of bedrockbtc
             },
         ],
     };
@@ -1299,22 +1300,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         pumpbtc_supervault_deposit_account_address
     );
 
-    let bedrock_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+    let bedrockbtc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
         admin: params.general.owner.clone(),
-        approved_libraries: vec![bedrock_supervaults_lper_library_address.clone()],
+        approved_libraries: vec![bedrockbtc_supervaults_lper_library_address.clone()],
     };
-    let bedrock_supervault_deposit_account_address = neutron_client
+    let bedrockbtc_supervault_deposit_account_address = neutron_client
         .instantiate2(
             code_id_base_account,
-            "bedrock_supervault_deposit".to_string(),
-            bedrock_deposit_account_instantiate_msg,
+            "bedrockbtc_supervault_deposit".to_string(),
+            bedrockbtc_deposit_account_instantiate_msg,
             Some(params.general.owner.clone()),
             salts[7].clone(),
         )
         .await?;
     println!(
-        "Bedrock-WBTC supervault deposit account instantiated: {}",
-        bedrock_supervault_deposit_account_address
+        "bedrockbtc-WBTC supervault deposit account instantiated: {}",
+        bedrockbtc_supervault_deposit_account_address
     );
 
     let maxbtc_btc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
@@ -1347,7 +1348,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             solvbtc_supervault_withdrawer_library_address.clone(),
             ebtc_supervault_withdrawer_library_address.clone(),
             pumpbtc_supervault_withdrawer_library_address.clone(),
-            bedrock_supervault_withdrawer_library_address.clone(),
+            bedrockbtc_supervault_withdrawer_library_address.clone(),
             maxbtc_issuer_library_address.clone(),
         ],
     };
@@ -1373,7 +1374,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         solvbtc_supervault_lp: params.program.solvbtc_supervault_lp_denom.clone(),
         ebtc_supervault_lp: params.program.ebtc_supervault_lp_denom.clone(),
         pumpbtc_supervault_lp: params.program.pumpbtc_supervault_lp_denom.clone(),
-        bedrock_supervault_lp: params.program.bedrock_supervault_lp_denom.clone(),
+        bedrockbtc_supervault_lp: params.program.bedrockbtc_supervault_lp_denom.clone(),
         maxbtc_supervault_lp: "TBD".to_string(), // This will need to be updated after phase shift
     };
 
@@ -1387,7 +1388,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         solvbtc_supervault_deposit: solvbtc_supervault_deposit_account_address,
         ebtc_supervault_deposit: ebtc_supervault_deposit_account_address,
         pumpbtc_supervault_deposit: pumpbtc_supervault_deposit_account_address,
-        bedrock_supervault_deposit: bedrock_supervault_deposit_account_address,
+        bedrockbtc_supervault_deposit: bedrockbtc_supervault_deposit_account_address,
         maxbtc_supervault_deposit: maxbtc_btc_supervault_deposit_account_address,
     };
 
@@ -1401,7 +1402,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         solvbtc_supervault_lper: solvbtc_supervaults_lper_library_address,
         ebtc_supervault_lper: ebtc_supervaults_lper_library_address,
         pumpbtc_supervault_lper: pumpbtc_supervaults_lper_library_address,
-        bedrock_supervault_lper: bedrock_supervaults_lper_library_address,
+        bedrockbtc_supervault_lper: bedrockbtc_supervaults_lper_library_address,
         maxbtc_supervault_lper: maxbtc_btc_supervaults_lper_library_address,
         phase_shift_splitter: phase_shift_splitter_library_address,
         phase_shift_forwarder: phase_shift_forwarder_library_address,
@@ -1411,7 +1412,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         phase_shift_solvbtc_supervault_withdrawer: solvbtc_supervault_withdrawer_library_address,
         phase_shift_ebtc_supervault_withdrawer: ebtc_supervault_withdrawer_library_address,
         phase_shift_pumpbtc_supervault_withdrawer: pumpbtc_supervault_withdrawer_library_address,
-        phase_shift_bedrock_supervault_withdrawer: bedrock_supervault_withdrawer_library_address,
+        phase_shift_bedrockbtc_supervault_withdrawer:
+            bedrockbtc_supervault_withdrawer_library_address,
     };
 
     let coprocessor_app_ids = NeutronCoprocessorAppIds {
@@ -1428,7 +1430,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         solvbtc_supervault: params.program.solvbtc_supervault.clone(),
         ebtc_supervault: params.program.ebtc_supervault.clone(),
         pumpbtc_supervault: params.program.pumpbtc_supervault.clone(),
-        bedrock_supervault: params.program.bedrock_supervault.clone(),
+        bedrockbtc_supervault: params.program.bedrockbtc_supervault.clone(),
         maxbtc_supervault: "TBD".to_string(), // This will need to be updated after phase shift
         denoms,
         accounts,

--- a/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
@@ -1,0 +1,1501 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    env,
+    error::Error,
+    fs,
+    str::FromStr,
+    time::SystemTime,
+};
+
+use cosmwasm_std::{Binary, Decimal, Uint64, Uint128};
+use serde::Deserialize;
+use sp1_sdk::{HashableKey, SP1VerifyingKey};
+use valence_clearing_queue_supervaults::msg::SupervaultSettlementInfo;
+use valence_domain_clients::{
+    clients::{coprocessor::CoprocessorClient, neutron::NeutronClient},
+    coprocessor::base_client::CoprocessorBaseClient,
+    cosmos::{grpc_client::GrpcSigningClient, wasm_client::WasmClient},
+};
+use wbtc_deploy::DIR;
+use wbtc_types::{
+    gaia_config::GaiaStrategyConfig,
+    neutron_config::{
+        NeutronAccounts, NeutronCoprocessorAppIds, NeutronDenoms, NeutronLibraries,
+        NeutronStrategyConfig,
+    },
+};
+
+use valence_dynamic_ratio_query_provider::msg::DenomSplitMap;
+use valence_forwarder_library::msg::ForwardingConstraints;
+use valence_library_utils::{LibraryAccountType, denoms::UncheckedDenom};
+use valence_splitter_library::msg::{UncheckedSplitAmount, UncheckedSplitConfig};
+
+#[derive(Deserialize, Debug)]
+struct UploadedContracts {
+    code_ids: HashMap<String, u64>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Parameters {
+    general: General,
+    ica: Ica,
+    program: Program,
+    coprocessor_app: CoprocessorApp,
+}
+
+#[derive(Deserialize, Debug)]
+struct General {
+    grpc_url: String,
+    grpc_port: String,
+    chain_id: String,
+    owner: String,
+    valence_owner: String,
+    strategist: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Ica {
+    deposit_token_on_hub_denom: String,
+    channel_id: String,
+    ibc_transfer_timeout: u64,
+    connection_id: String,
+    ica_timeout: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct Program {
+    deposit_token_on_neutron_denom: String,
+    mars_credit_manager: String,
+    fbtc_supervault: String,
+    fbtc_supervault_asset1: String,
+    fbtc_supervault_asset2: String,
+    fbtc_supervault_lp_denom: String,
+    lbtc_supervault: String,
+    lbtc_supervault_asset1: String,
+    lbtc_supervault_asset2: String,
+    lbtc_supervault_lp_denom: String,
+    solvbtc_supervault: String,
+    solvbtc_supervault_asset1: String,
+    solvbtc_supervault_asset2: String,
+    solvbtc_supervault_lp_denom: String,
+    ebtc_supervault: String,
+    ebtc_supervault_asset1: String,
+    ebtc_supervault_asset2: String,
+    ebtc_supervault_lp_denom: String,
+    pumpbtc_supervault: String,
+    pumpbtc_supervault_asset1: String,
+    pumpbtc_supervault_asset2: String,
+    pumpbtc_supervault_lp_denom: String,
+    bedrock_supervault: String,
+    bedrock_supervault_asset1: String,
+    bedrock_supervault_asset2: String,
+    bedrock_supervault_lp_denom: String,
+    initial_split_mars_ratio: String,
+    initial_split_fbtc_ratio: String,
+    initial_split_lbtc_ratio: String,
+    initial_split_solvbtc_ratio: String,
+    initial_split_ebtc_ratio: String,
+    initial_split_pumpbtc_ratio: String,
+    initial_split_bedrockbtc_ratio: String,
+    mars_settlement_ratio: String,
+    fbtc_settlement_ratio_percentage: u64,
+    lbtc_settlement_ratio_percentage: u64,
+    solvbtc_settlement_ratio_percentage: u64,
+    ebtc_settlement_ratio_percentage: u64,
+    pumpbtc_settlement_ratio_percentage: u64,
+    bedrock_settlement_ratio_percentage: u64,
+    fbtc_denom: String,
+    lbtc_denom: String,
+    solvbtc_denom: String,
+    ebtc_denom: String,
+    pumpbtc_denom: String,
+    bedrockbtc_denom: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct CoprocessorApp {
+    clearing_queue_coprocessor_app_id: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    dotenv::dotenv().ok();
+    let mnemonic = env::var("MNEMONIC").expect("mnemonic must be provided");
+
+    let current_dir = env::current_dir()?;
+
+    let parameters = fs::read_to_string(current_dir.join(format!("{DIR}/neutron.toml")))
+        .expect("Failed to read file");
+
+    let params: Parameters = toml::from_str(&parameters).expect("Failed to parse TOML");
+
+    // Read code IDS from the code ids file
+    let code_ids_content =
+        fs::read_to_string(current_dir.join(format!("{DIR}/neutron_code_ids.toml")))
+            .expect("Failed to read code ids file");
+    let uploaded_contracts: UploadedContracts =
+        toml::from_str(&code_ids_content).expect("Failed to parse code ids");
+
+    let neutron_client = NeutronClient::new(
+        &params.general.grpc_url,
+        &params.general.grpc_port,
+        &mnemonic,
+        &params.general.chain_id,
+    )
+    .await?;
+
+    let my_address = neutron_client
+        .get_signing_client()
+        .await?
+        .address
+        .to_string();
+
+    // Get all code IDs
+    let code_id_authorization = *uploaded_contracts.code_ids.get("authorization").unwrap();
+    let code_id_processor = *uploaded_contracts.code_ids.get("processor").unwrap();
+    let code_id_ica_ibc_transfer_library =
+        *uploaded_contracts.code_ids.get("ica_ibc_transfer").unwrap();
+    let code_id_splitter_library = *uploaded_contracts.code_ids.get("splitter_library").unwrap();
+    let code_id_forwarder_library = *uploaded_contracts
+        .code_ids
+        .get("forwarder_library")
+        .unwrap();
+    let code_id_mars_lending = *uploaded_contracts.code_ids.get("mars_lending").unwrap();
+    let code_id_supervaults_lper = *uploaded_contracts.code_ids.get("supervaults_lper").unwrap();
+    let code_id_supervaults_withdrawer = *uploaded_contracts
+        .code_ids
+        .get("supervaults_withdrawer")
+        .unwrap();
+    let code_id_clearing_queue = *uploaded_contracts
+        .code_ids
+        .get("clearing_queue_supervaults")
+        .unwrap();
+    let code_id_base_account = *uploaded_contracts.code_ids.get("base_account").unwrap();
+    let code_id_interchain_account = *uploaded_contracts
+        .code_ids
+        .get("interchain_account")
+        .unwrap();
+    let code_id_verification_gateway = *uploaded_contracts
+        .code_ids
+        .get("verification_gateway")
+        .unwrap();
+    let code_id_dynamic_ratio_query_provider = *uploaded_contracts
+        .code_ids
+        .get("dynamic_ratio_query_provider")
+        .unwrap();
+    let code_id_maxbtc_issuer = *uploaded_contracts.code_ids.get("maxbtc_issuer").unwrap();
+
+    let now = SystemTime::now();
+    let salt_raw = now
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_secs()
+        .to_string();
+    let salt = hex::encode(salt_raw.as_bytes());
+
+    let predicted_processor_address = neutron_client
+        .predict_instantiate2_addr(code_id_processor, salt.clone(), my_address.clone())
+        .await?
+        .address;
+
+    // Owner will initially be the deploy address and eventually will be transferred to the owned address
+    let authorization_instantiate_msg = valence_authorization_utils::msg::InstantiateMsg {
+        owner: my_address.clone(),
+        sub_owners: vec![],
+        processor: predicted_processor_address.clone(),
+    };
+
+    let authorization_address = neutron_client
+        .instantiate2(
+            code_id_authorization,
+            "authorization".to_string(),
+            authorization_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salt.clone(),
+        )
+        .await?;
+    println!("Authorization instantiated: {}", authorization_address);
+
+    let processor_instantiate_msg = valence_processor_utils::msg::InstantiateMsg {
+        authorization_contract: authorization_address.clone(),
+        polytone_contracts: None,
+    };
+
+    let processor_address = neutron_client
+        .instantiate2(
+            code_id_processor,
+            "processor".to_string(),
+            processor_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salt.clone(),
+        )
+        .await?;
+    println!("Processor instantiated: {}", processor_address);
+
+    // Instantiate the verification gateway
+    // Get the domain verification key from coprocessor
+    let coprocessor_client = CoprocessorClient::default();
+    let domain_vk = coprocessor_client.get_domain_vk().await?;
+    let sp1_domain_vk: SP1VerifyingKey = bincode::deserialize(&domain_vk)?;
+
+    // TODO: We might have a verification gateway already deployed so no need to deploy another one if that's the case
+    let instantiate_verification_gateway_msg = valence_verification_gateway::msg::InstantiateMsg {
+        owner: params.general.valence_owner.clone(),
+        domain_vk: Binary::from(sp1_domain_vk.bytes32().as_bytes()),
+    };
+
+    let verification_gateway = neutron_client
+        .instantiate(
+            code_id_verification_gateway,
+            "verification-gateway".to_string(),
+            instantiate_verification_gateway_msg,
+            None,
+        )
+        .await?;
+
+    // Set the verification gateway address on the authorization contract
+    let set_verification_gateway_msg =
+        valence_authorization_utils::msg::ExecuteMsg::PermissionedAction(
+            valence_authorization_utils::msg::PermissionedMsg::SetVerificationGateway {
+                verification_gateway,
+            },
+        );
+
+    neutron_client
+        .execute_wasm(
+            &authorization_address,
+            set_verification_gateway_msg,
+            vec![],
+            None,
+        )
+        .await?;
+
+    // Predict all base accounts, we are going to store all salts for them as well. In total we need 4
+    let mut salts = vec![];
+    let mut predicted_base_accounts = vec![];
+    // We now will have 7 supervault deposit accounts, including the maxBTC-BTC vault one which will come later when the vault launches
+    for i in 0..10 {
+        let salt = hex::encode(format!("{}{}", salt_raw, i).as_bytes());
+        salts.push(salt.clone());
+        let predicted_base_account_address = neutron_client
+            .predict_instantiate2_addr(code_id_base_account, salt.clone(), my_address.clone())
+            .await?
+            .address;
+        println!(
+            "Predicted base account address {}: {}",
+            i, predicted_base_account_address
+        );
+        predicted_base_accounts.push(predicted_base_account_address);
+    }
+
+    // Predict the valence ICA address
+    let predicted_valence_ica_address = neutron_client
+        .predict_instantiate2_addr(code_id_interchain_account, salt.clone(), my_address.clone())
+        .await?
+        .address;
+
+    // Instantiate the ICA ibc transfer library
+    let config = valence_ica_ibc_transfer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_valence_ica_address.clone()),
+        // The strategist needs to update this to the actual amount that needs to be transferred. There will be an authorization for this.
+        amount: Uint128::one(),
+        denom: params.ica.deposit_token_on_hub_denom.clone(),
+        receiver: predicted_base_accounts[0].clone(),
+        memo: "".to_string(),
+        remote_chain_info: valence_ica_ibc_transfer::msg::RemoteChainInfo {
+            channel_id: params.ica.channel_id,
+            ibc_transfer_timeout: Some(params.ica.ibc_transfer_timeout),
+        },
+        denom_to_pfm_map: BTreeMap::new(),
+        eureka_config: None,
+    };
+
+    let instantiate_ica_ibc_transfer_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_ica_ibc_transfer::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config,
+    };
+
+    // Instantiate the ICA IBC transfer library
+    let ica_ibc_transfer_library_address = neutron_client
+        .instantiate(
+            code_id_ica_ibc_transfer_library,
+            "ica_ibc_transfer".to_string(),
+            instantiate_ica_ibc_transfer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "ICA IBC Transfer library instantiated: {}",
+        ica_ibc_transfer_library_address
+    );
+
+    // Instantiate the Dynamic ratio query provider library
+    let receiver_to_split_perc = HashMap::from([
+        (
+            predicted_base_accounts[1].clone(), // Mars deposit account
+            Decimal::from_str(&params.program.initial_split_mars_ratio).unwrap(),
+        ),
+        (
+            predicted_base_accounts[2].clone(), // FBTC WBTC supervault deposit account
+            Decimal::from_str(&params.program.initial_split_fbtc_ratio).unwrap(),
+        ),
+        (
+            predicted_base_accounts[3].clone(), // LBTC WBTC supervault deposit account
+            Decimal::from_str(&params.program.initial_split_lbtc_ratio).unwrap(),
+        ),
+        (
+            predicted_base_accounts[4].clone(), // SolvBTC WBTC supervault deposit account
+            Decimal::from_str(&params.program.initial_split_solvbtc_ratio).unwrap(),
+        ),
+        (
+            predicted_base_accounts[5].clone(), // eBTC WBTC supervault deposit account
+            Decimal::from_str(&params.program.initial_split_ebtc_ratio).unwrap(),
+        ),
+        (
+            predicted_base_accounts[6].clone(), // PumpBTC WBTC supervault deposit account
+            Decimal::from_str(&params.program.initial_split_pumpbtc_ratio).unwrap(),
+        ),
+        (
+            predicted_base_accounts[7].clone(), // Bedrock WBTC supervault deposit account
+            Decimal::from_str(&params.program.initial_split_bedrockbtc_ratio).unwrap(),
+        ),
+    ]);
+
+    let denom_to_splits = HashMap::from([(
+        params.program.deposit_token_on_neutron_denom.clone(),
+        receiver_to_split_perc,
+    )]);
+
+    let dynamic_ratio_query_provider_instantiate_msg =
+        valence_dynamic_ratio_query_provider::msg::InstantiateMsg {
+            admin: params.general.strategist,
+            split_cfg: DenomSplitMap {
+                split_cfg: denom_to_splits,
+            },
+        };
+
+    let dynamic_ratio_query_provider_address = neutron_client
+        .instantiate(
+            code_id_dynamic_ratio_query_provider,
+            "dynamic_ratio_query_provider".to_string(),
+            dynamic_ratio_query_provider_instantiate_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Dynamic ratio query provider library instantiated: {}",
+        dynamic_ratio_query_provider_address
+    );
+
+    // Instantiate the deposit splitter library
+    // This library will split to the Mars deposit account and the Supervault deposit accounts
+    let deposit_splitter_config = valence_splitter_library::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[0].clone()),
+        splits: vec![
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[1].clone()), // Mars deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[1].clone(),
+                },
+            },
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[2].clone()), // FBTC WBTC supervault deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[2].clone(),
+                },
+            },
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[3].clone()), // LBTC WBTC supervault deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[3].clone(),
+                },
+            },
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[4].clone()), // SolvBTC WBTC supervault deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[4].clone(),
+                },
+            },
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[5].clone()), // eBTC WBTC supervault deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[5].clone(),
+                },
+            },
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[6].clone()), // PumpBTC WBTC supervault deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[6].clone(),
+                },
+            },
+            valence_splitter_library::msg::UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(
+                    params.program.deposit_token_on_neutron_denom.clone(),
+                ),
+                account: LibraryAccountType::Addr(predicted_base_accounts[7].clone()), // Bedrock WBTC supervault deposit account
+                amount: UncheckedSplitAmount::DynamicRatio {
+                    contract_addr: dynamic_ratio_query_provider_address.clone(),
+                    params: predicted_base_accounts[7].clone(),
+                },
+            },
+        ],
+    };
+
+    let instantiate_deposit_splitter_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_splitter_library::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: deposit_splitter_config,
+    };
+
+    let deposit_splitter_library_address = neutron_client
+        .instantiate(
+            code_id_splitter_library,
+            "deposit_splitter".to_string(),
+            instantiate_deposit_splitter_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Deposit splitter library instantiated: {}",
+        deposit_splitter_library_address
+    );
+
+    // Instantiate the Mars lending library
+    // In Phase 1 the output account is the settlement account and in phase 2 this will be initial deposit account
+    let mars_lending_config = valence_mars_lending::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[1].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        credit_manager_addr: params.program.mars_credit_manager,
+        denom: params.program.deposit_token_on_neutron_denom.clone(),
+    };
+
+    let instantiate_mars_lending_msg =
+        valence_library_utils::msg::InstantiateMsg::<valence_mars_lending::msg::LibraryConfig> {
+            owner: processor_address.clone(),
+            processor: processor_address.clone(),
+            config: mars_lending_config,
+        };
+
+    let mars_lending_library_address = neutron_client
+        .instantiate(
+            code_id_mars_lending,
+            "mars_lending".to_string(),
+            instantiate_mars_lending_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Mars lending library instantiated: {}",
+        mars_lending_library_address
+    );
+
+    // Instantiate all supervaults lper library
+    let supervaults_fbtc_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[2].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.fbtc_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.fbtc_supervault_asset1.clone(),
+                asset2: params.program.fbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.fbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_fbtc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: supervaults_fbtc_lper_config,
+    };
+    let fbtc_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "fbtc_supervault_lper".to_string(),
+            instantiate_fbtc_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "FBTC-WBTC Supervaults lper library instantiated: {}",
+        fbtc_supervaults_lper_library_address
+    );
+
+    let lbtc_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[3].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.lbtc_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.lbtc_supervault_asset1.clone(),
+                asset2: params.program.lbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.lbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_lbtc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: lbtc_supervaults_lper_config,
+    };
+
+    let lbtc_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "lbtc_supervault_lper".to_string(),
+            instantiate_lbtc_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+
+    println!(
+        "LBTC-WBTC Supervaults lper library instantiated: {}",
+        lbtc_supervaults_lper_library_address
+    );
+
+    let solvbtc_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[4].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.solvbtc_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.solvbtc_supervault_asset1.clone(),
+                asset2: params.program.solvbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.solvbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_solvbtc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: solvbtc_supervaults_lper_config,
+    };
+    let solvbtc_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "solvbtc_supervault_lper".to_string(),
+            instantiate_solvbtc_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "SolvBTC-WBTC Supervaults lper library instantiated: {}",
+        solvbtc_supervaults_lper_library_address
+    );
+
+    let ebtc_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[5].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.ebtc_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.ebtc_supervault_asset1.clone(),
+                asset2: params.program.ebtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.ebtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_ebtc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: ebtc_supervaults_lper_config,
+    };
+
+    let ebtc_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "ebtc_supervault_lper".to_string(),
+            instantiate_ebtc_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "eBTC-WBTC Supervaults lper library instantiated: {}",
+        ebtc_supervaults_lper_library_address
+    );
+
+    let pumpbtc_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[6].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.pumpbtc_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.pumpbtc_supervault_asset1.clone(),
+                asset2: params.program.pumpbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.pumpbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_pumpbtc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: pumpbtc_supervaults_lper_config,
+    };
+    let pumpbtc_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "pumpbtc_supervault_lper".to_string(),
+            instantiate_pumpbtc_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "PumpBTC-WBTC Supervaults lper library instantiated: {}",
+        pumpbtc_supervaults_lper_library_address
+    );
+
+    let bedrock_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[7].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.bedrock_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.bedrock_supervault_asset1.clone(),
+                asset2: params.program.bedrock_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.bedrock_supervault_lp_denom.clone(),
+        },
+    };
+    let instantiate_bedrock_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: bedrock_supervaults_lper_config,
+    };
+    let bedrock_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "bedrock_supervault_lper".to_string(),
+            instantiate_bedrock_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Bedrock-WBTC Supervaults lper library instantiated: {}",
+        bedrock_supervaults_lper_library_address
+    );
+
+    // We'll also instantiate the maxBTC-BTC one even though we don't have the address yet,
+    // but we will update it later, this way we can set up the authorizations for it already
+    // We'll use the FBTC-WBTC supervault lper library address and parameters as placeholders
+    let maxbtc_btc_supervaults_lper_config = valence_supervaults_lper::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[8].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.fbtc_supervault.clone(),
+        lp_config: valence_supervaults_lper::msg::LiquidityProviderConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.fbtc_supervault_asset1.clone(),
+                asset2: params.program.fbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.fbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_maxbtc_btc_supervaults_lper_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_lper::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: maxbtc_btc_supervaults_lper_config,
+    };
+    let maxbtc_btc_supervaults_lper_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_lper,
+            "maxbtc_btc_supervault_lper".to_string(),
+            instantiate_maxbtc_btc_supervaults_lper_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Placeholer MaxBTC-BTC Supervaults lper library instantiated: {}",
+        maxbtc_btc_supervaults_lper_library_address
+    );
+
+    // Finally instantiate the clearing queue library
+    let clearing_config = valence_clearing_queue_supervaults::msg::LibraryConfig {
+        settlement_acc_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        denom: params.program.deposit_token_on_neutron_denom.clone(),
+        latest_id: None,
+        mars_settlement_ratio: Decimal::from_str(&params.program.mars_settlement_ratio).unwrap(),
+        supervaults_settlement_info: vec![
+            SupervaultSettlementInfo {
+                supervault_addr: params.program.fbtc_supervault.clone(),
+                supervault_sender: predicted_base_accounts[2].clone(), // Input account of supervaults lper library
+                settlement_ratio: Decimal::percent(params.program.fbtc_settlement_ratio_percentage),
+            },
+            SupervaultSettlementInfo {
+                supervault_addr: params.program.lbtc_supervault.clone(),
+                supervault_sender: predicted_base_accounts[3].clone(),
+                settlement_ratio: Decimal::percent(params.program.lbtc_settlement_ratio_percentage),
+            },
+            SupervaultSettlementInfo {
+                supervault_addr: params.program.solvbtc_supervault.clone(),
+                supervault_sender: predicted_base_accounts[4].clone(),
+                settlement_ratio: Decimal::percent(
+                    params.program.solvbtc_settlement_ratio_percentage,
+                ),
+            },
+            SupervaultSettlementInfo {
+                supervault_addr: params.program.ebtc_supervault.clone(),
+                supervault_sender: predicted_base_accounts[5].clone(),
+                settlement_ratio: Decimal::percent(params.program.ebtc_settlement_ratio_percentage),
+            },
+            SupervaultSettlementInfo {
+                supervault_addr: params.program.pumpbtc_supervault.clone(),
+                supervault_sender: predicted_base_accounts[6].clone(),
+                settlement_ratio: Decimal::percent(
+                    params.program.pumpbtc_settlement_ratio_percentage,
+                ),
+            },
+            SupervaultSettlementInfo {
+                supervault_addr: params.program.bedrock_supervault.clone(),
+                supervault_sender: predicted_base_accounts[7].clone(),
+                settlement_ratio: Decimal::percent(
+                    params.program.bedrock_settlement_ratio_percentage,
+                ),
+            },
+        ],
+    };
+
+    let instantiate_clearing_queue_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_clearing_queue_supervaults::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: clearing_config,
+    };
+
+    let clearing_queue_library_address = neutron_client
+        .instantiate(
+            code_id_clearing_queue,
+            "clearing_queue".to_string(),
+            instantiate_clearing_queue_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Clearing queue library instantiated: {}",
+        clearing_queue_library_address
+    );
+
+    ////////// Instantiate and set up everything we need for the phase shift. The authorization that will eventually //////////
+    ////////// update the config and execute these libraries will be for the program owner, in this case the Neutron //////////
+    ////////// program DAO set up for this.                                                                          //////////
+
+    // 1. Instantiate all the supervaults withdrawers that will withdraw the LP tokens from the supervault and deposit the deposit token + the other pair
+    // in the settlement account.
+    let fbtc_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()), // Both input and output are settlement account
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.fbtc_supervault.clone(),
+        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.fbtc_supervault_asset1.clone(),
+                asset2: params.program.fbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.fbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_fbtc_supervaults_withdrawer_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_withdrawer::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: fbtc_supervault_withdrawer_config,
+    };
+    let fbtc_supervault_withdrawer_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_withdrawer,
+            "supervaults_withdrawer".to_string(),
+            instantiate_fbtc_supervaults_withdrawer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "FBTC-WBTC Supervaults withdrawer library instantiated: {}",
+        fbtc_supervault_withdrawer_library_address
+    );
+
+    let lbtc_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.lbtc_supervault.clone(),
+        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.lbtc_supervault_asset1.clone(),
+                asset2: params.program.lbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.lbtc_supervault_lp_denom.clone(),
+        },
+    };
+
+    let instantiate_lbtc_supervaults_withdrawer_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_withdrawer::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: lbtc_supervault_withdrawer_config,
+    };
+    let lbtc_supervault_withdrawer_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_withdrawer,
+            "lbtc_supervault_withdrawer".to_string(),
+            instantiate_lbtc_supervaults_withdrawer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "LBTC-WBTC Supervaults withdrawer library instantiated: {}",
+        lbtc_supervault_withdrawer_library_address
+    );
+
+    let solvbtc_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.solvbtc_supervault.clone(),
+        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.solvbtc_supervault_asset1.clone(),
+                asset2: params.program.solvbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.solvbtc_supervault_lp_denom.clone(),
+        },
+    };
+    let instantiate_solvbtc_supervaults_withdrawer_msg =
+        valence_library_utils::msg::InstantiateMsg::<
+            valence_supervaults_withdrawer::msg::LibraryConfig,
+        > {
+            owner: processor_address.clone(),
+            processor: processor_address.clone(),
+            config: solvbtc_supervault_withdrawer_config,
+        };
+    let solvbtc_supervault_withdrawer_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_withdrawer,
+            "solvbtc_supervault_withdrawer".to_string(),
+            instantiate_solvbtc_supervaults_withdrawer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "SolvBTC-WBTC Supervaults withdrawer library instantiated: {}",
+        solvbtc_supervault_withdrawer_library_address
+    );
+
+    let ebtc_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.ebtc_supervault.clone(),
+        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.ebtc_supervault_asset1.clone(),
+                asset2: params.program.ebtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.ebtc_supervault_lp_denom.clone(),
+        },
+    };
+    let instantiate_ebtc_supervaults_withdrawer_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_supervaults_withdrawer::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: ebtc_supervault_withdrawer_config,
+    };
+    let ebtc_supervault_withdrawer_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_withdrawer,
+            "ebtc_supervault_withdrawer".to_string(),
+            instantiate_ebtc_supervaults_withdrawer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "eBTC-WBTC Supervaults withdrawer library instantiated: {}",
+        ebtc_supervault_withdrawer_library_address
+    );
+
+    let pumpbtc_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.pumpbtc_supervault.clone(),
+        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.pumpbtc_supervault_asset1.clone(),
+                asset2: params.program.pumpbtc_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.pumpbtc_supervault_lp_denom.clone(),
+        },
+    };
+    let instantiate_pumpbtc_supervaults_withdrawer_msg =
+        valence_library_utils::msg::InstantiateMsg::<
+            valence_supervaults_withdrawer::msg::LibraryConfig,
+        > {
+            owner: processor_address.clone(),
+            processor: processor_address.clone(),
+            config: pumpbtc_supervault_withdrawer_config,
+        };
+    let pumpbtc_supervault_withdrawer_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_withdrawer,
+            "pumpbtc_supervault_withdrawer".to_string(),
+            instantiate_pumpbtc_supervaults_withdrawer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "PumpBTC-WBTC Supervaults withdrawer library instantiated: {}",
+        pumpbtc_supervault_withdrawer_library_address
+    );
+
+    let bedrock_supervault_withdrawer_config = valence_supervaults_withdrawer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        vault_addr: params.program.bedrock_supervault.clone(),
+        lw_config: valence_supervaults_withdrawer::msg::LiquidityWithdrawerConfig {
+            asset_data: valence_library_utils::liquidity_utils::AssetData {
+                asset1: params.program.bedrock_supervault_asset1.clone(),
+                asset2: params.program.bedrock_supervault_asset2.clone(),
+            },
+            lp_denom: params.program.bedrock_supervault_lp_denom.clone(),
+        },
+    };
+    let instantiate_bedrock_supervaults_withdrawer_msg =
+        valence_library_utils::msg::InstantiateMsg::<
+            valence_supervaults_withdrawer::msg::LibraryConfig,
+        > {
+            owner: processor_address.clone(),
+            processor: processor_address.clone(),
+            config: bedrock_supervault_withdrawer_config,
+        };
+    let bedrock_supervault_withdrawer_library_address = neutron_client
+        .instantiate(
+            code_id_supervaults_withdrawer,
+            "bedrock_supervault_withdrawer".to_string(),
+            instantiate_bedrock_supervaults_withdrawer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Bedrock-WBTC Supervaults withdrawer library instantiated: {}",
+        bedrock_supervault_withdrawer_library_address
+    );
+
+    // 2. Instantiate the maxbtc issuer that will issue the maxbtc token depositing the counterparty of the deposit token in the vault.
+    // The output address will be the deposit account for the supervault
+    let supervault_other_asset =
+        if params.program.fbtc_supervault_asset1 == params.program.deposit_token_on_neutron_denom {
+            params.program.fbtc_supervault_asset2.clone()
+        } else {
+            params.program.fbtc_supervault_asset1.clone()
+        };
+
+    let maxbtc_issuer_config = valence_maxbtc_issuer::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()),
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[8].clone()), // Deposit address of the maxBTC supervault
+        maxbtc_issuer_addr: params.general.owner.clone(), // We are going to put a dummy address here (the owner for example) because this will be eventually updated
+        btc_denom: supervault_other_asset, // The counterparty asset of the vault (WBTC)
+    };
+    let instantiate_maxbtc_issuer_msg =
+        valence_library_utils::msg::InstantiateMsg::<valence_maxbtc_issuer::msg::LibraryConfig> {
+            owner: processor_address.clone(),
+            processor: processor_address.clone(),
+            config: maxbtc_issuer_config,
+        };
+    let maxbtc_issuer_library_address = neutron_client
+        .instantiate(
+            code_id_maxbtc_issuer,
+            "maxbtc_issuer".to_string(),
+            instantiate_maxbtc_issuer_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "MaxBTC issuer library instantiated: {}",
+        maxbtc_issuer_library_address
+    );
+
+    // 3. Instantiate the splitter library that will return all LSTs to their corresponding LST deposit accounts
+    let splitter_config = valence_splitter_library::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()), // Settlement account
+        splits: vec![
+            UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(params.program.fbtc_denom.clone()),
+                account: LibraryAccountType::Addr(predicted_base_accounts[2].clone()), // FBTC deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of FBTC
+            },
+            UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(params.program.lbtc_denom.clone()),
+                account: LibraryAccountType::Addr(predicted_base_accounts[3].clone()), // LBTC deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of LBTC
+            },
+            UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(params.program.solvbtc_denom.clone()),
+                account: LibraryAccountType::Addr(predicted_base_accounts[4].clone()), // SolvBTC deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of SolvBTC
+            },
+            UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(params.program.ebtc_denom.clone()),
+                account: LibraryAccountType::Addr(predicted_base_accounts[5].clone()), // eBTC deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of eBTC
+            },
+            UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(params.program.pumpbtc_denom.clone()),
+                account: LibraryAccountType::Addr(predicted_base_accounts[6].clone()), // PumpBTC deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of PumpBTC
+            },
+            UncheckedSplitConfig {
+                denom: UncheckedDenom::Native(params.program.bedrockbtc_denom.clone()),
+                account: LibraryAccountType::Addr(predicted_base_accounts[7].clone()), // BedrockBTC deposit account
+                amount: UncheckedSplitAmount::FixedRatio(Decimal::one()), // 100% of Bedrock
+            },
+        ],
+    };
+
+    let instantiate_splitter_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_splitter_library::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: splitter_config,
+    };
+    let phase_shift_splitter_library_address = neutron_client
+        .instantiate(
+            code_id_splitter_library,
+            "phase_shift_splitter".to_string(),
+            instantiate_splitter_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Phase shift splitter library instantiated: {}",
+        phase_shift_splitter_library_address
+    );
+
+    // 4. Instantiate the phase shift forwarder library that will forward wBTC to the deposit account
+    // of the maxBTC-WBTC supervault
+    let phase_shift_forwarder_config = valence_forwarder_library::msg::LibraryConfig {
+        input_addr: LibraryAccountType::Addr(predicted_base_accounts[9].clone()), // Settlement account
+        output_addr: LibraryAccountType::Addr(predicted_base_accounts[8].clone()), // Deposit account of the maxBTC supervault
+        forwarding_configs: vec![valence_forwarder_library::msg::UncheckedForwardingConfig {
+            denom: UncheckedDenom::Native(params.program.deposit_token_on_neutron_denom.clone()),
+            max_amount: Uint128::MAX,
+        }],
+        forwarding_constraints: ForwardingConstraints::default(),
+    };
+    let instantiate_phase_shift_forwarder_msg = valence_library_utils::msg::InstantiateMsg::<
+        valence_forwarder_library::msg::LibraryConfig,
+    > {
+        owner: processor_address.clone(),
+        processor: processor_address.clone(),
+        config: phase_shift_forwarder_config,
+    };
+    let phase_shift_forwarder_library_address = neutron_client
+        .instantiate(
+            code_id_forwarder_library,
+            "phase_shift_forwarder".to_string(),
+            instantiate_phase_shift_forwarder_msg,
+            None,
+        )
+        .await?;
+    println!(
+        "Phase shift forwarder library instantiated: {}",
+        phase_shift_forwarder_library_address
+    );
+
+    //////////                           //////////
+    //////////  End of phase shift setup //////////
+    //////////                           //////////
+
+    // Instantiate all acounts now
+    // First the ICA
+    let valence_ica_instantiate_msg = valence_account_utils::ica::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![ica_ibc_transfer_library_address.clone()],
+        remote_domain_information: valence_account_utils::ica::RemoteDomainInfo {
+            connection_id: params.ica.connection_id.clone(),
+            ica_timeout_seconds: Uint64::from(params.ica.ica_timeout),
+        },
+    };
+    let valence_ica_address = neutron_client
+        .instantiate2(
+            code_id_interchain_account,
+            "valence_ica".to_string(),
+            valence_ica_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salt.clone(),
+        )
+        .await?;
+    println!("Valence ICA instantiated: {}", valence_ica_address);
+
+    // Now the rest
+    let ica_deposit_account = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![deposit_splitter_library_address.clone()],
+    };
+    let ica_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "ica_deposit".to_string(),
+            ica_deposit_account,
+            Some(params.general.owner.clone()),
+            salts[0].clone(),
+        )
+        .await?;
+    println!(
+        "ICA deposit account instantiated: {}",
+        ica_deposit_account_address
+    );
+
+    let mars_deposit_account = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![mars_lending_library_address.clone()],
+    };
+    let mars_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "mars_deposit".to_string(),
+            mars_deposit_account,
+            Some(params.general.owner.clone()),
+            salts[1].clone(),
+        )
+        .await?;
+    println!(
+        "Mars deposit account instantiated: {}",
+        mars_deposit_account_address
+    );
+
+    let fbtc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![fbtc_supervaults_lper_library_address.clone()],
+    };
+    let fbtc_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "fbtc_supervault_deposit".to_string(),
+            fbtc_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[2].clone(),
+        )
+        .await?;
+    println!(
+        "FBTC-WBTC supervault deposit account instantiated: {}",
+        fbtc_supervault_deposit_account_address
+    );
+
+    let lbtc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![lbtc_supervaults_lper_library_address.clone()],
+    };
+    let lbtc_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "lbtc_supervault_deposit".to_string(),
+            lbtc_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[3].clone(),
+        )
+        .await?;
+    println!(
+        "LBTC-WBTC supervault deposit account instantiated: {}",
+        lbtc_supervault_deposit_account_address
+    );
+
+    let solvbtc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![solvbtc_supervaults_lper_library_address.clone()],
+    };
+
+    let solvbtc_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "solvbtc_supervault_deposit".to_string(),
+            solvbtc_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[4].clone(),
+        )
+        .await?;
+    println!(
+        "SolvBTC-WBTC supervault deposit account instantiated: {}",
+        solvbtc_supervault_deposit_account_address
+    );
+
+    let ebtc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![ebtc_supervaults_lper_library_address.clone()],
+    };
+    let ebtc_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "ebtc_supervault_deposit".to_string(),
+            ebtc_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[5].clone(),
+        )
+        .await?;
+    println!(
+        "eBTC-WBTC supervault deposit account instantiated: {}",
+        ebtc_supervault_deposit_account_address
+    );
+
+    let pumpbtc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![pumpbtc_supervaults_lper_library_address.clone()],
+    };
+    let pumpbtc_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "pumpbtc_supervault_deposit".to_string(),
+            pumpbtc_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[6].clone(),
+        )
+        .await?;
+    println!(
+        "PumpBTC-WBTC supervault deposit account instantiated: {}",
+        pumpbtc_supervault_deposit_account_address
+    );
+
+    let bedrock_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![bedrock_supervaults_lper_library_address.clone()],
+    };
+    let bedrock_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "bedrock_supervault_deposit".to_string(),
+            bedrock_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[7].clone(),
+        )
+        .await?;
+    println!(
+        "Bedrock-WBTC supervault deposit account instantiated: {}",
+        bedrock_supervault_deposit_account_address
+    );
+
+    let maxbtc_btc_deposit_account_instantiate_msg = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![maxbtc_btc_supervaults_lper_library_address.clone()],
+    };
+    let maxbtc_btc_supervault_deposit_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "maxbtc_btc_supervault_deposit".to_string(),
+            maxbtc_btc_deposit_account_instantiate_msg,
+            Some(params.general.owner.clone()),
+            salts[8].clone(),
+        )
+        .await?;
+    println!(
+        "MaxBTC-BTC supervault deposit account instantiated: {}",
+        maxbtc_btc_supervault_deposit_account_address
+    );
+
+    let settlement_account = valence_account_utils::msg::InstantiateMsg {
+        admin: params.general.owner.clone(),
+        approved_libraries: vec![
+            // This will contain all libraries that will execute actions on the settlement account
+            clearing_queue_library_address.clone(),
+            phase_shift_splitter_library_address.clone(),
+            phase_shift_forwarder_library_address.clone(),
+            fbtc_supervault_withdrawer_library_address.clone(),
+            lbtc_supervault_withdrawer_library_address.clone(),
+            solvbtc_supervault_withdrawer_library_address.clone(),
+            ebtc_supervault_withdrawer_library_address.clone(),
+            pumpbtc_supervault_withdrawer_library_address.clone(),
+            bedrock_supervault_withdrawer_library_address.clone(),
+            maxbtc_issuer_library_address.clone(),
+        ],
+    };
+    let settlement_account_address = neutron_client
+        .instantiate2(
+            code_id_base_account,
+            "settlement".to_string(),
+            settlement_account,
+            Some(params.general.owner.clone()),
+            salts[9].clone(),
+        )
+        .await?;
+    println!(
+        "Settlement account instantiated: {}",
+        settlement_account_address
+    );
+
+    let denoms = NeutronDenoms {
+        deposit_token: params.program.deposit_token_on_neutron_denom,
+        ntrn: "untrn".to_string(),
+        fbtc_supervault_lp: params.program.fbtc_supervault_lp_denom.clone(),
+        lbtc_supervault_lp: params.program.lbtc_supervault_lp_denom.clone(),
+        solvbtc_supervault_lp: params.program.solvbtc_supervault_lp_denom.clone(),
+        ebtc_supervault_lp: params.program.ebtc_supervault_lp_denom.clone(),
+        pumpbtc_supervault_lp: params.program.pumpbtc_supervault_lp_denom.clone(),
+        bedrock_supervault_lp: params.program.bedrock_supervault_lp_denom.clone(),
+        maxbtc_supervault_lp: "TBD".to_string(), // This will need to be updated after phase shift
+    };
+
+    let accounts = NeutronAccounts {
+        ica: valence_ica_address.clone(),
+        deposit: ica_deposit_account_address,
+        mars_deposit: mars_deposit_account_address,
+        settlement: settlement_account_address,
+        fbtc_supervault_deposit: fbtc_supervault_deposit_account_address,
+        lbtc_supervault_deposit: lbtc_supervault_deposit_account_address,
+        solvbtc_supervault_deposit: solvbtc_supervault_deposit_account_address,
+        ebtc_supervault_deposit: ebtc_supervault_deposit_account_address,
+        pumpbtc_supervault_deposit: pumpbtc_supervault_deposit_account_address,
+        bedrock_supervault_deposit: bedrock_supervault_deposit_account_address,
+        maxbtc_supervault_deposit: maxbtc_btc_supervault_deposit_account_address,
+    };
+
+    let libraries = NeutronLibraries {
+        deposit_splitter: deposit_splitter_library_address,
+        mars_lending: mars_lending_library_address,
+        clearing_queue: clearing_queue_library_address,
+        ica_transfer: ica_ibc_transfer_library_address,
+        fbtc_supervault_lper: fbtc_supervaults_lper_library_address,
+        lbtc_supervault_lper: lbtc_supervaults_lper_library_address,
+        solvbtc_supervault_lper: solvbtc_supervaults_lper_library_address,
+        ebtc_supervault_lper: ebtc_supervaults_lper_library_address,
+        pumpbtc_supervault_lper: pumpbtc_supervaults_lper_library_address,
+        bedrock_supervault_lper: bedrock_supervaults_lper_library_address,
+        maxbtc_supervault_lper: maxbtc_btc_supervaults_lper_library_address,
+        phase_shift_splitter: phase_shift_splitter_library_address,
+        phase_shift_forwarder: phase_shift_forwarder_library_address,
+        phase_shift_maxbtc_issuer: maxbtc_issuer_library_address,
+        phase_shift_fbtc_supervault_withdrawer: fbtc_supervault_withdrawer_library_address,
+        phase_shift_lbtc_supervault_withdrawer: lbtc_supervault_withdrawer_library_address,
+        phase_shift_solvbtc_supervault_withdrawer: solvbtc_supervault_withdrawer_library_address,
+        phase_shift_ebtc_supervault_withdrawer: ebtc_supervault_withdrawer_library_address,
+        phase_shift_pumpbtc_supervault_withdrawer: pumpbtc_supervault_withdrawer_library_address,
+        phase_shift_bedrock_supervault_withdrawer: bedrock_supervault_withdrawer_library_address,
+    };
+
+    let coprocessor_app_ids = NeutronCoprocessorAppIds {
+        clearing_queue: params.coprocessor_app.clearing_queue_coprocessor_app_id,
+    };
+
+    let neutron_cfg = NeutronStrategyConfig {
+        grpc_url: params.general.grpc_url.clone(),
+        grpc_port: params.general.grpc_port.clone(),
+        chain_id: params.general.chain_id.clone(),
+        mars_pool: "mars pool".to_string(),
+        fbtc_supervault: params.program.fbtc_supervault.clone(),
+        lbtc_supervault: params.program.lbtc_supervault.clone(),
+        solvbtc_supervault: params.program.solvbtc_supervault.clone(),
+        ebtc_supervault: params.program.ebtc_supervault.clone(),
+        pumpbtc_supervault: params.program.pumpbtc_supervault.clone(),
+        bedrock_supervault: params.program.bedrock_supervault.clone(),
+        maxbtc_supervault: "TBD".to_string(), // This will need to be updated after phase shift
+        denoms,
+        accounts,
+        libraries,
+        min_ibc_fee: Uint128::one(),
+        authorizations: authorization_address,
+        processor: processor_address,
+        coprocessor_app_ids,
+    };
+
+    println!("Neutron Strategy Config created successfully");
+
+    // Save the Neutron Strategy Config to a toml file
+    let neutron_cfg_toml =
+        toml::to_string(&neutron_cfg).expect("Failed to serialize Neutron Strategy Config");
+    fs::write(
+        current_dir.join("deploy/src/neutron_strategy_config.toml"),
+        neutron_cfg_toml,
+    )
+    .expect("Failed to write Neutron Strategy Config to file");
+
+    // Last thing we will do is register the ICA on the valence ICA
+    let register_ica_msg = valence_account_utils::ica::ExecuteMsg::RegisterIca {};
+    neutron_client
+        .execute_wasm(
+            &valence_ica_address,
+            register_ica_msg,
+            vec![cosmrs::Coin::new(1_000_000u128, "untrn").unwrap()],
+            None,
+        )
+        .await?;
+
+    println!("Registering ICA...");
+
+    // Let's wait enough time for the transaction to succeed and the ICA to be registered
+    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+
+    // Let's query now to get the ICA address
+    let query_ica = valence_account_utils::ica::QueryMsg::IcaState {};
+    let ica_state: valence_account_utils::ica::IcaState = neutron_client
+        .query_contract_state(&valence_ica_address, query_ica)
+        .await?;
+
+    let ica_address = match ica_state {
+        valence_account_utils::ica::IcaState::Created(ica_information) => ica_information.address,
+        _ => {
+            panic!("ICA creation failed!, state: {:?}", ica_state);
+        }
+    };
+    println!("ICA address: {}", ica_address);
+
+    let gaia_cfg = GaiaStrategyConfig {
+        grpc_url: "grpc_url".to_string(),
+        grpc_port: "grpc_port".to_string(),
+        chain_id: "chain_id".to_string(),
+        chain_denom: "uatom".to_string(),
+        deposit_denom: params.ica.deposit_token_on_hub_denom.clone(),
+        ica_address,
+    };
+
+    // Write the Gaia strategy config to a file
+    let gaia_cfg_path = current_dir.join(format!("{DIR}/gaia_strategy_config.toml"));
+    fs::write(
+        gaia_cfg_path,
+        toml::to_string(&gaia_cfg).expect("Failed to serialize Gaia strategy config"),
+    )
+    .expect("Failed to write Gaia strategy config to file");
+
+    Ok(())
+}

--- a/strategies/wbtc/deploy/src/bin/neutron_initialization.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_initialization.rs
@@ -220,7 +220,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .clone(),
         ntrn_strategy_config
             .libraries
-            .bedrock_supervault_lper
+            .bedrockbtc_supervault_lper
             .clone(),
     ] {
         let provide_liquidity_function = AtomicFunction {
@@ -274,7 +274,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .clone(),
         ntrn_strategy_config
             .libraries
-            .bedrock_supervault_lper
+            .bedrockbtc_supervault_lper
             .clone(),
         ntrn_strategy_config
             .libraries
@@ -425,7 +425,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .clone(),
         ntrn_strategy_config
             .libraries
-            .bedrock_supervault_lper
+            .bedrockbtc_supervault_lper
             .clone(),
     ] {
         let withdraw_function = AtomicFunction {
@@ -513,7 +513,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .clone(),
         ntrn_strategy_config
             .libraries
-            .bedrock_supervault_lper
+            .bedrockbtc_supervault_lper
             .clone(),
         ntrn_strategy_config
             .libraries

--- a/strategies/wbtc/deploy/src/bin/neutron_initialization.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_initialization.rs
@@ -1,0 +1,797 @@
+use std::{env, error::Error, fs};
+
+use cosmwasm_std::Binary;
+use serde::Deserialize;
+use sp1_sdk::{HashableKey, SP1VerifyingKey};
+use valence_authorization_utils::{
+    authorization::{AtomicSubroutine, AuthorizationModeInfo, PermissionTypeInfo, Subroutine},
+    authorization_message::{Message, MessageDetails, MessageType, ParamRestriction},
+    builders::{AtomicSubroutineBuilder, AuthorizationBuilder},
+    domain::Domain,
+    function::AtomicFunction,
+    zk_authorization::ZkAuthorizationInfo,
+};
+use valence_domain_clients::{
+    clients::{coprocessor::CoprocessorClient, neutron::NeutronClient},
+    coprocessor::base_client::CoprocessorBaseClient,
+    cosmos::wasm_client::WasmClient,
+};
+use valence_library_utils::LibraryAccountType;
+use wbtc_deploy::DIR;
+use wbtc_types::{
+    labels::{
+        ICA_TRANSFER_LABEL, LEND_AND_PROVIDE_LIQUIDITY_PHASE1_LABEL,
+        LEND_AND_PROVIDE_LIQUIDITY_PHASE2_LABEL, MARS_WITHDRAW_LABEL, PHASE_SHIFT_STEP1_LABEL,
+        PHASE_SHIFT_STEP2_LABEL, PHASE_SHIFT_STEP3_LABEL, PHASE_SHIFT_STEP4_LABEL,
+        REGISTER_OBLIGATION_LABEL, SETTLE_OBLIGATION_LABEL,
+    },
+    neutron_config::NeutronStrategyConfig,
+};
+
+#[derive(Deserialize, Debug)]
+struct Parameters {
+    general: General,
+    coprocessor_app: CoprocessorApp,
+}
+
+#[derive(Deserialize, Debug)]
+struct General {
+    owner: String,
+    strategist: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct CoprocessorApp {
+    clearing_queue_coprocessor_app_id: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    dotenv::dotenv().ok();
+    let mnemonic = env::var("MNEMONIC").expect("mnemonic must be provided");
+
+    let current_dir = env::current_dir()?;
+
+    let ntrn_params = fs::read_to_string(current_dir.join(format!("{DIR}/neutron.toml")))
+        .expect("Failed to read file");
+
+    let ntrn_params: Parameters =
+        toml::from_str(&ntrn_params).expect("Failed to parse Neutron parameters");
+
+    let strategist = ntrn_params.general.strategist;
+
+    let ntrn_cfg =
+        fs::read_to_string(current_dir.join(format!("{DIR}/neutron_strategy_config.toml")))
+            .expect("Failed to read file");
+
+    let ntrn_strategy_config: NeutronStrategyConfig =
+        toml::from_str(&ntrn_cfg).expect("Failed to parse Neutron strategy config");
+
+    let authorization_contract = ntrn_strategy_config.authorizations;
+
+    let neutron_client = NeutronClient::new(
+        &ntrn_strategy_config.grpc_url,
+        &ntrn_strategy_config.grpc_port,
+        &mnemonic,
+        &ntrn_strategy_config.chain_id,
+    )
+    .await?;
+
+    let mut authorizations = vec![];
+
+    // All authorizations except the phase shift one will be called by strategist
+    let authorization_permissioned_mode =
+        AuthorizationModeInfo::Permissioned(PermissionTypeInfo::WithoutCallLimit(vec![
+            strategist.clone(),
+        ]));
+
+    // Subroutine for ICA Transfer
+    // Involves updating the amount and trigger the transfer
+    let update_amount_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                // Well only allow updating the amount, any other update will be rejected
+                name: "update_config".to_string(),
+                params_restrictions: Some(vec![
+                    ParamRestriction::MustBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "amount".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "input_addr".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "denom".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "receiver".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "memo".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "remote_chain_info".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "denom_to_pfm_map".to_string(),
+                    ]),
+                ]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.ica_transfer.clone(),
+        ),
+    };
+
+    let transfer_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                // Only allow calling transfer
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "transfer".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(ntrn_strategy_config.libraries.ica_transfer),
+    };
+
+    let subroutine_ica_transfer = AtomicSubroutineBuilder::new()
+        .with_function(update_amount_function)
+        .with_function(transfer_function)
+        .build();
+
+    let authorization_ica_transfer = AuthorizationBuilder::new()
+        .with_label(ICA_TRANSFER_LABEL)
+        .with_mode(authorization_permissioned_mode.clone())
+        .with_subroutine(subroutine_ica_transfer)
+        .build();
+
+    authorizations.push(authorization_ica_transfer);
+
+    // Subroutine for Mars lending and Supervault LP providing which involves Split, Lend and Deposit to all supervaults
+    // This one is for Phase 1
+    let split_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "split".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.deposit_splitter.clone(),
+        ),
+    };
+    let lend_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "lend".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.mars_lending.clone(),
+        ),
+    };
+
+    let mut lend_and_provide_liquidity_phase1_functions = vec![];
+    lend_and_provide_liquidity_phase1_functions.push(split_function.clone());
+    lend_and_provide_liquidity_phase1_functions.push(lend_function.clone());
+    // Create all provide liquidity functions for each supervault
+    for address in [
+        ntrn_strategy_config.libraries.fbtc_supervault_lper.clone(),
+        ntrn_strategy_config.libraries.lbtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .solvbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config.libraries.ebtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .pumpbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config
+            .libraries
+            .bedrock_supervault_lper
+            .clone(),
+    ] {
+        let provide_liquidity_function = AtomicFunction {
+            domain: Domain::Main,
+            message_details: MessageDetails {
+                message_type: MessageType::CosmwasmExecuteMsg,
+                message: Message {
+                    name: "process_function".to_string(),
+                    params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                        "process_function".to_string(),
+                        "provide_liquidity".to_string(),
+                    ])]),
+                },
+            },
+            contract_address: LibraryAccountType::Addr(address.clone()),
+        };
+        lend_and_provide_liquidity_phase1_functions.push(provide_liquidity_function);
+    }
+
+    let subroutine_lending_and_providing_liquidity_phase1 = Subroutine::Atomic(AtomicSubroutine {
+        functions: lend_and_provide_liquidity_phase1_functions,
+        retry_logic: None,
+        expiration_time: None,
+    });
+
+    let authorization_lending_and_providing_liquidity = AuthorizationBuilder::new()
+        .with_label(LEND_AND_PROVIDE_LIQUIDITY_PHASE1_LABEL)
+        .with_mode(authorization_permissioned_mode.clone())
+        .with_subroutine(subroutine_lending_and_providing_liquidity_phase1)
+        .build();
+    authorizations.push(authorization_lending_and_providing_liquidity);
+
+    // Subroutine for Mars lending and Supervault LP providing which involves Split, Lend and Deposit to all supervaults
+    // This one is for Phase 2
+    let mut lend_and_provide_liquidity_phase2_functions = vec![];
+    lend_and_provide_liquidity_phase2_functions.push(split_function.clone());
+    lend_and_provide_liquidity_phase2_functions.push(lend_function.clone());
+    // Create all provide liquidity functions for each supervault
+    // This one includes the new maxBTC supervault
+    for address in [
+        ntrn_strategy_config.libraries.fbtc_supervault_lper.clone(),
+        ntrn_strategy_config.libraries.lbtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .solvbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config.libraries.ebtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .pumpbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config
+            .libraries
+            .bedrock_supervault_lper
+            .clone(),
+        ntrn_strategy_config
+            .libraries
+            .maxbtc_supervault_lper
+            .clone(),
+    ] {
+        let provide_liquidity_function = AtomicFunction {
+            domain: Domain::Main,
+            message_details: MessageDetails {
+                message_type: MessageType::CosmwasmExecuteMsg,
+                message: Message {
+                    name: "process_function".to_string(),
+                    params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                        "process_function".to_string(),
+                        "provide_liquidity".to_string(),
+                    ])]),
+                },
+            },
+            contract_address: LibraryAccountType::Addr(address.clone()),
+        };
+        lend_and_provide_liquidity_phase2_functions.push(provide_liquidity_function);
+    }
+
+    let subroutine_lending_and_providing_liquidity_phase2 = Subroutine::Atomic(AtomicSubroutine {
+        functions: lend_and_provide_liquidity_phase2_functions,
+        retry_logic: None,
+        expiration_time: None,
+    });
+
+    let authorization_lending_and_providing_liquidity = AuthorizationBuilder::new()
+        .with_label(LEND_AND_PROVIDE_LIQUIDITY_PHASE2_LABEL)
+        .with_mode(authorization_permissioned_mode.clone())
+        .with_subroutine(subroutine_lending_and_providing_liquidity_phase2)
+        .build();
+    authorizations.push(authorization_lending_and_providing_liquidity);
+
+    // Authorization for Mars withdrawing
+    let withdraw_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "withdraw".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.mars_lending.clone(),
+        ),
+    };
+    let subroutine_mars_withdraw = AtomicSubroutineBuilder::new()
+        .with_function(withdraw_function)
+        .build();
+    let authorization_mars_withdraw = AuthorizationBuilder::new()
+        .with_label(MARS_WITHDRAW_LABEL)
+        .with_mode(authorization_permissioned_mode.clone())
+        .with_subroutine(subroutine_mars_withdraw)
+        .build();
+    authorizations.push(authorization_mars_withdraw);
+
+    // Authorization for settle obligation
+    let settle_obligation_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "settle_next_obligation".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.clearing_queue.clone(),
+        ),
+    };
+
+    let subroutine_settle_obligation = AtomicSubroutineBuilder::new()
+        .with_function(settle_obligation_function)
+        .build();
+    let authorization_settle_obligation = AuthorizationBuilder::new()
+        .with_label(SETTLE_OBLIGATION_LABEL)
+        .with_mode(authorization_permissioned_mode.clone())
+        .with_subroutine(subroutine_settle_obligation)
+        .build();
+    authorizations.push(authorization_settle_obligation);
+
+    //////// PHASE SHIFT AUTHORIZATIONS ////////
+    // These authorizations are special, they will be executed from the Program owner via DAODAO in order
+    // and involves multiple steps including updating configs with values we don't know during deployment
+    let owner_mode =
+        AuthorizationModeInfo::Permissioned(PermissionTypeInfo::WithoutCallLimit(vec![
+            ntrn_params.general.owner.clone(),
+        ]));
+
+    // AUTHORIZATION 1 - STEPS:
+    // 1) Update the maxBTC issuer with the right config (address of the maxBTC contract that we didn't have before)
+    // 2) Withdraw from all supervaults the lent WBTC, we will get both WBTC and the other pair back
+    // 3) Issue the maxBTC with all the BTC we got from the supervaults
+    // 4) Trigger the split to return all LSTs to their corresponding deposit accounts
+
+    let mut functions = vec![];
+    // Update the maxBTC issuer with the right config
+    let update_maxbtc_issuer_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "update_config".to_string(),
+                params_restrictions: Some(vec![
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "input_addr".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "output_addr".to_string(),
+                    ]),
+                ]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config
+                .libraries
+                .phase_shift_maxbtc_issuer
+                .clone(),
+        ),
+    };
+    functions.push(update_maxbtc_issuer_function);
+
+    for supervault in [
+        ntrn_strategy_config.libraries.fbtc_supervault_lper.clone(),
+        ntrn_strategy_config.libraries.lbtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .solvbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config.libraries.ebtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .pumpbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config
+            .libraries
+            .bedrock_supervault_lper
+            .clone(),
+    ] {
+        let withdraw_function = AtomicFunction {
+            domain: Domain::Main,
+            message_details: MessageDetails {
+                message_type: MessageType::CosmwasmExecuteMsg,
+                message: Message {
+                    name: "process_function".to_string(),
+                    params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                        "process_function".to_string(),
+                        "withdraw".to_string(),
+                    ])]),
+                },
+            },
+            contract_address: LibraryAccountType::Addr(supervault.clone()),
+        };
+        functions.push(withdraw_function);
+    }
+
+    let issue_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "issue".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config
+                .libraries
+                .phase_shift_maxbtc_issuer
+                .clone(),
+        ),
+    };
+    functions.push(issue_function);
+    let split_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "split".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.deposit_splitter.clone(),
+        ),
+    };
+    functions.push(split_function);
+
+    let subroutine_phase_shift_step1 = Subroutine::Atomic(AtomicSubroutine {
+        functions,
+        retry_logic: None,
+        expiration_time: None,
+    });
+    let authorization_phase_shift_step1 = AuthorizationBuilder::new()
+        .with_label(PHASE_SHIFT_STEP1_LABEL)
+        .with_mode(owner_mode.clone())
+        .with_subroutine(subroutine_phase_shift_step1)
+        .build();
+    authorizations.push(authorization_phase_shift_step1);
+
+    // AUTHORIZATION 2 - STEPS:
+    // 1) Update all the supervaults to use the new maxBTC supervault pair
+    // 2) Trigger the deposit in all of them
+    let mut functions = vec![];
+    for supervault in [
+        ntrn_strategy_config.libraries.fbtc_supervault_lper.clone(),
+        ntrn_strategy_config.libraries.lbtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .solvbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config.libraries.ebtc_supervault_lper.clone(),
+        ntrn_strategy_config
+            .libraries
+            .pumpbtc_supervault_lper
+            .clone(),
+        ntrn_strategy_config
+            .libraries
+            .bedrock_supervault_lper
+            .clone(),
+        ntrn_strategy_config
+            .libraries
+            .maxbtc_supervault_lper
+            .clone(),
+    ] {
+        let update_function = AtomicFunction {
+            domain: Domain::Main,
+            message_details: MessageDetails {
+                message_type: MessageType::CosmwasmExecuteMsg,
+                message: Message {
+                    name: "update_config".to_string(),
+                    params_restrictions: Some(vec![
+                        ParamRestriction::CannotBeIncluded(vec![
+                            "update_config".to_string(),
+                            "new_config".to_string(),
+                            "input_addr".to_string(),
+                        ]),
+                        ParamRestriction::CannotBeIncluded(vec![
+                            "update_config".to_string(),
+                            "new_config".to_string(),
+                            "output_addr".to_string(),
+                        ]),
+                    ]),
+                },
+            },
+            contract_address: LibraryAccountType::Addr(supervault.clone()),
+        };
+        let provide_liquidity_function = AtomicFunction {
+            domain: Domain::Main,
+            message_details: MessageDetails {
+                message_type: MessageType::CosmwasmExecuteMsg,
+                message: Message {
+                    name: "process_function".to_string(),
+                    params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                        "process_function".to_string(),
+                        "provide_liquidity".to_string(),
+                    ])]),
+                },
+            },
+            contract_address: LibraryAccountType::Addr(supervault.clone()),
+        };
+        functions.push(update_function);
+        functions.push(provide_liquidity_function);
+    }
+
+    let subroutine_phase_shift_step2 = Subroutine::Atomic(AtomicSubroutine {
+        functions,
+        retry_logic: None,
+        expiration_time: None,
+    });
+    let authorization_phase_shift_step2 = AuthorizationBuilder::new()
+        .with_label(PHASE_SHIFT_STEP2_LABEL)
+        .with_mode(owner_mode.clone())
+        .with_subroutine(subroutine_phase_shift_step2)
+        .build();
+    authorizations.push(authorization_phase_shift_step2);
+
+    // AUTHORIZATION 3 - STEPS:
+    // 1) Withdraw half of the lent WBTC from Mars,
+    // 2) Update the forwarder to send half of this amount to the maxBTC wBTC deposit account,
+    // 3) Forward the funds
+    // 4) Issue the maxBTC by depositing the other half of the WBTC
+    // 5) Deposit in the maxBTC supervault
+
+    let withdraw_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "withdraw".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.mars_lending.clone(),
+        ),
+    };
+    let update_forwarder_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "update_config".to_string(),
+                params_restrictions: Some(vec![
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "input_addr".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "output_addr".to_string(),
+                    ]),
+                ]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.phase_shift_forwarder.clone(),
+        ),
+    };
+    let forward_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "forward".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.phase_shift_forwarder.clone(),
+        ),
+    };
+    let issue_maxbtc_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "issue".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config
+                .libraries
+                .phase_shift_maxbtc_issuer
+                .clone(),
+        ),
+    };
+    let provide_liquidity_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "process_function".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::MustBeIncluded(vec![
+                    "process_function".to_string(),
+                    "provide_liquidity".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config
+                .libraries
+                .maxbtc_supervault_lper
+                .clone(),
+        ),
+    };
+
+    let subroutine_settle_obligation = AtomicSubroutineBuilder::new()
+        .with_function(withdraw_function)
+        .with_function(update_forwarder_function)
+        .with_function(forward_function)
+        .with_function(issue_maxbtc_function)
+        .with_function(provide_liquidity_function)
+        .build();
+    let authorization_phase_shift_step3 = AuthorizationBuilder::new()
+        .with_label(PHASE_SHIFT_STEP3_LABEL)
+        .with_mode(owner_mode.clone())
+        .with_subroutine(subroutine_settle_obligation)
+        .build();
+    authorizations.push(authorization_phase_shift_step3);
+
+    // AUTHORIZATION 4 - STEPS:
+    // 1) Update the new split config to use the new phase 2 ratios
+    // 2) Update the clearing queue config to use the new settlement ratios
+    let update_splitter_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "update_config".to_string(),
+                params_restrictions: Some(vec![ParamRestriction::CannotBeIncluded(vec![
+                    "update_config".to_string(),
+                    "new_config".to_string(),
+                    "input_addr".to_string(),
+                ])]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.deposit_splitter.clone(),
+        ),
+    };
+    let update_clearing_queue_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "update_config".to_string(),
+                params_restrictions: Some(vec![
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "settlement_acc_addr".to_string(),
+                    ]),
+                    ParamRestriction::CannotBeIncluded(vec![
+                        "update_config".to_string(),
+                        "new_config".to_string(),
+                        "denom".to_string(),
+                    ]),
+                ]),
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config.libraries.clearing_queue.clone(),
+        ),
+    };
+
+    let subroutine_phase_shift_step4 = AtomicSubroutineBuilder::new()
+        .with_function(update_splitter_function)
+        .with_function(update_clearing_queue_function)
+        .build();
+    let authorization_phase_shift_step4 = AuthorizationBuilder::new()
+        .with_label(PHASE_SHIFT_STEP4_LABEL)
+        .with_mode(owner_mode)
+        .with_subroutine(subroutine_phase_shift_step4)
+        .build();
+    authorizations.push(authorization_phase_shift_step4);
+
+    // Add all authorizations to the authorization contract
+    let create_authorizations = valence_authorization_utils::msg::ExecuteMsg::PermissionedAction(
+        valence_authorization_utils::msg::PermissionedMsg::CreateAuthorizations { authorizations },
+    );
+
+    neutron_client
+        .execute_wasm(&authorization_contract, create_authorizations, vec![], None)
+        .await?;
+    println!("Authorizations created successfully");
+
+    // Get the VK for the coprocessor app
+    let coprocessor_client = CoprocessorClient::default();
+    let program_vk = coprocessor_client
+        .get_vk(
+            &ntrn_params
+                .coprocessor_app
+                .clearing_queue_coprocessor_app_id,
+        )
+        .await?;
+
+    let sp1_program_vk: SP1VerifyingKey = bincode::deserialize(&program_vk)?;
+
+    // Now we create the zk authorization
+    let zk_authorization = ZkAuthorizationInfo {
+        label: REGISTER_OBLIGATION_LABEL.to_string(),
+        mode: authorization_permissioned_mode,
+        registry: 0,
+        vk: Binary::from(sp1_program_vk.bytes32().as_bytes()),
+        validate_last_block_execution: false,
+    };
+
+    let create_zk_authorization = valence_authorization_utils::msg::ExecuteMsg::PermissionedAction(
+        valence_authorization_utils::msg::PermissionedMsg::CreateZkAuthorizations {
+            zk_authorizations: vec![zk_authorization],
+        },
+    );
+
+    neutron_client
+        .execute_wasm(
+            &authorization_contract,
+            create_zk_authorization,
+            vec![],
+            None,
+        )
+        .await?;
+    println!("ZK Authorization created successfully");
+
+    // TODO: Transfer ownership of authorization contract to owner
+
+    Ok(())
+}

--- a/strategies/wbtc/deploy/src/bin/neutron_upload.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_upload.rs
@@ -1,0 +1,59 @@
+use std::{collections::HashMap, env, error::Error, fs};
+
+use serde::{Deserialize, Serialize};
+use valence_domain_clients::{clients::neutron::NeutronClient, cosmos::wasm_client::WasmClient};
+use wbtc_deploy::DIR;
+
+const GRPC_URL: &str = "https://rpc.neutron.quokkastake.io";
+const GRPC_PORT: &str = "9090";
+const CHAIN_ID: &str = "neutron-1";
+
+#[derive(Deserialize, Serialize)]
+struct UploadedContracts {
+    code_ids: HashMap<String, u64>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    dotenv::dotenv().ok();
+    let mnemonic = env::var("MNEMONIC").expect("mnemonic must be provided");
+
+    let neutron_client = NeutronClient::new(GRPC_URL, GRPC_PORT, &mnemonic, CHAIN_ID).await?;
+
+    let mut uploaded_contracts = UploadedContracts {
+        code_ids: HashMap::new(),
+    };
+
+    // Upload all contracts that are in /packages/src/contracts/cw
+    for entry in std::fs::read_dir("./packages/src/contracts/cw")? {
+        let entry = entry?;
+        if entry.path().is_file() {
+            let contract_name = entry.file_name().to_string_lossy().to_string();
+            println!("Uploading contract: {}", contract_name);
+            let code_id = neutron_client
+                .upload_code(entry.path().to_str().unwrap())
+                .await?;
+
+            // Remove .wasm extension and valence_ prefix
+            let clean_name = contract_name
+                .strip_prefix("valence_")
+                .unwrap_or(&contract_name);
+            let clean_name = clean_name
+                .strip_suffix(".wasm")
+                .unwrap_or(clean_name)
+                .to_string();
+
+            uploaded_contracts.code_ids.insert(clean_name, code_id);
+        }
+    }
+
+    let toml_content = toml::to_string_pretty(&uploaded_contracts)?;
+    let current_dir = env::current_dir()?;
+    fs::write(
+        current_dir.join(format!("{DIR}/neutron_code_ids.toml")),
+        toml_content.clone(),
+    )?;
+
+    println!("Contracts uploaded!");
+    Ok(())
+}

--- a/strategies/wbtc/deploy/src/ethereum.toml
+++ b/strategies/wbtc/deploy/src/ethereum.toml
@@ -1,0 +1,28 @@
+[general]
+rpc_url = "https://eth-mainnet.public.blastapi.io"
+owner   = "0xd9A23b58e684B985F661Ce7005AA8E10630150c1" # Neutron multisig address
+valence_owner = "0xd9A23b58e684B985F661Ce7005AA8E10630150c1" # TBD Owner of the verification gateway
+coprocessor_root = "0x0000000000000000000000000000000000000000000000000000000000000000" # Bytes32 hash of coprocessor root
+
+[vault]
+deposit_token            = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+strategist               = "0x510c4a1d637ff374399826f421003b775dc3e8dc" # Address of the strategist
+platform_fee_account     = "0x510c4a1d637ff374399826f421003b775dc3e8dc" # Receiver of the platform fees portion
+strategist_fee_account   = "0x510c4a1d637ff374399826f421003b775dc3e8dc" # Receiver of the strategist fees portion
+strategist_fee_ratio_bps = 5000                                         # Strategist fee is 50%, rest goes to the platform (50%)
+scaling_factor           = "1000000000000"                                # scaling factor for rate updates
+deposit_cap              = "10000000000000"                             # e.g. 10K BTC
+deposit_fee_bps          = 100                                          # 1% deposit fee
+withdraw_rate_bps        = 100                                          # 1% withdrawal rate
+starting_rate            = "100000000"                                  # 1e8 - WBTC Precision
+max_rate_update_delay    = 345600                                       # 4 days in seconds - Maximum delay for rate updates before vault gets paused
+
+[eureka_transfer]
+handler                    = "0xfc2d0487a0ae42ae7329a80dc269916a9184cf7c"
+recipient                  = "cosmos1n0u7xtm75u5y4gvl8e0qx6xjdl7pspzv560dsysn956rlakq9wrqh03z0d"
+source_client              = "cosmoshub-0"
+timeout                    = 43200                                        # 12 hours in seconds
+ibc_transfer_threshold_amt = 1000000
+
+[coprocessor_app]
+eureka_transfer_coprocessor_app_id = "c4cfc3d0b2b278e6c1d4dd239c102093d48711c3bb6b0b76b318b1736f5742b3" # TBD after we have the app deployed

--- a/strategies/wbtc/deploy/src/lib.rs
+++ b/strategies/wbtc/deploy/src/lib.rs
@@ -1,0 +1,2 @@
+pub const DIR: &str = "strategies/wbtc/deploy/src";
+pub const SP1_VERIFIER: &str = "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B";

--- a/strategies/wbtc/deploy/src/neutron.toml
+++ b/strategies/wbtc/deploy/src/neutron.toml
@@ -1,0 +1,67 @@
+[general]
+grpc_url   = "https://rpc.neutron.quokkastake.io"
+grpc_port  = "9090"
+chain_id   = "neutron-1"
+owner      = "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp" # Should be Neutron multisig
+valence_owner = "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp" # TBD Valence address that will own the verification gateway
+strategist = "neutron1z8qjsmtjxcd36j0la2rs2rfstf5nxmady2hx8a" # Should be strategist address
+
+[ica]
+deposit_token_on_hub_denom = "ibc/D742E8566B0B8CC8F569D950051C09CF57988A88F0E45574BFB3079D41DE6462" # WBTC
+channel_id                 = "channel-569"                                                          # Hub -> Neutron channel
+ibc_transfer_timeout       = 600                                                                    # 10 minutes
+connection_id              = "connection-0"                                                         # Neutron -> Hub connection
+ica_timeout                = 43200                                                                  # 12 hours in seconds - Large value recommended: https://docs.neutron.org/neutron/modules/interchain-txs/messages
+
+[program]
+deposit_token_on_neutron_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # WBTC
+mars_credit_manager = "neutron1scjuh29rzffqzhgxusjd56f7qnf7r9e6rwxym6n65h9d3kkhfrqs0xm4dn" # Need to figure this out, not sure if this one
+fbtc_supervault = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y" # TBD
+fbtc_supervault_asset1 = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+fbtc_supervault_asset2 = "ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B" # TBD
+fbtc_supervault_lp_denom = "factory/neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y/BTC-BTC" # TBD after supervaults are deployed
+lbtc_supervault = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y" # TBD
+lbtc_supervault_asset1 = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+lbtc_supervault_asset2 = "ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B" # TBD
+lbtc_supervault_lp_denom = "factory/neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y/BTC-BTC" # TBD after supervaults are deployed
+solvbtc_supervault = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y" # TBD
+solvbtc_supervault_asset1 = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+solvbtc_supervault_asset2 = "ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B" # TBD
+solvbtc_supervault_lp_denom = "factory/neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y/BTC-BTC" # TBD after supervaults are deployed
+ebtc_supervault = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y" # TBD
+ebtc_supervault_asset1 = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+ebtc_supervault_asset2 = "ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B" # TBD
+ebtc_supervault_lp_denom = "factory/neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y/BTC-BTC" # TBD after supervaults are deployed
+pumpbtc_supervault = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y" # TBD
+pumpbtc_supervault_asset1 = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+pumpbtc_supervault_asset2 = "ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B" # TBD
+pumpbtc_supervault_lp_denom = "factory/neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y/BTC-BTC" # TBD after supervaults are deployed
+bedrockbtc_supervault = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y" # TBD
+bedrockbtc_supervault_asset1 = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+bedrockbtc_supervault_asset2 = "ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B" # TBD
+bedrockbtc_supervault_lp_denom = "factory/neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y/BTC-BTC" # TBD after supervaults are deployed
+initial_split_mars_ratio = "0.67"
+initial_split_fbtc_ratio = "0.0825" # 25% of remaining 33%
+initial_split_lbtc_ratio = "0.0825" 
+initial_split_solvbtc_ratio = "0.0495" # 15% of remaining 33%
+initial_split_ebtc_ratio = "0.0495"
+initial_split_pumpbtc_ratio = "0.033" # 10% of remaining 33%
+initial_split_bedrockbtc_ratio = "0.033"
+# This means 67 will be settled on Mars and 33% will be settled on Supervaults
+mars_settlement_ratio = "0.67"
+# For each supervault, what % of amount settled on Supervaults will be settled on it
+fbtc_settlement_ratio_percentage = 25
+lbtc_settlement_ratio_percentage = 25
+solvbtc_settlement_ratio_percentage = 15
+ebtc_settlement_ratio_percentage = 15
+pumpbtc_settlement_ratio_percentage = 10
+bedrockbtc_settlement_ratio_percentage = 10
+fbtc_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+lbtc_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+solvbtc_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+ebtc_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+pumpbtc_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+bedrockbtc_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # TBD
+
+[coprocessor_app]
+clearing_queue_coprocessor_app_id = "f8923f9f3da06b726fbaf1a41a6a375c86ff2180f8c11a60d1f7ad90ac9b4281" # TBD after we have the app deployed

--- a/strategies/wbtc/deploy/src/neutron_code_ids.toml
+++ b/strategies/wbtc/deploy/src/neutron_code_ids.toml
@@ -1,0 +1,15 @@
+[code_ids]
+supervaults_withdrawer       = 3830
+verification_gateway         = 3772
+clearing_queue_supervaults   = 3832
+dynamic_ratio_query_provider = 3769
+supervaults_lper             = 3829
+forwarder_library            = 3701
+splitter_library             = 3771
+authorization                = 3820
+interchain_account           = 3770
+ica_ibc_transfer             = 3778
+mars_lending                 = 3775
+base_account                 = 3773
+processor                    = 3776
+maxbtc_issuer                = 3804

--- a/strategies/wbtc/types/Cargo.toml
+++ b/strategies/wbtc/types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wbtc_types"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+cosmwasm-std                = { workspace = true }
+serde                       = { workspace = true }
+valence-strategist-utils    = { workspace = true }
+alloy                       = { workspace = true }

--- a/strategies/wbtc/types/src/coprocessor_config.rs
+++ b/strategies/wbtc/types/src/coprocessor_config.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoprocessorStrategyConfig {
+    /// coprocessor circuit IDs
+    pub eureka_circuit_id: String,
+    pub vault_circuit_id: String,
+}
+
+impl ValenceWorkerTomlSerde for CoprocessorStrategyConfig {}

--- a/strategies/wbtc/types/src/ethereum_config.rs
+++ b/strategies/wbtc/types/src/ethereum_config.rs
@@ -1,0 +1,60 @@
+use alloy::primitives::{Address, U256};
+use cosmwasm_std::Uint128;
+use serde::{Deserialize, Serialize};
+use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EthereumStrategyConfig {
+    /// ethereum node rpc url
+    pub rpc_url: String,
+
+    /// minimum eureka-transfer input account balance
+    /// to perform IBC transfer (taking fees into account)
+    pub ibc_transfer_threshold_amt: U256,
+
+    /// update rate scaling factor
+    pub rate_scaling_factor: Uint128,
+
+    /// authorizations module
+    pub authorizations: Address,
+    /// lite-processor coupled with the authorizations
+    pub processor: Address,
+
+    /// all denoms relevant to the eth-side of strategy
+    pub denoms: EthereumDenoms,
+    /// all accounts relevant to the eth-side of strategy
+    pub accounts: EthereumAccounts,
+    /// all libraries relevant to the eth-side of strategy
+    pub libraries: EthereumLibraries,
+    /// all coprocessor app ids relevant to the eth-side of strategy
+    pub coprocessor_app_ids: EthereumCoprocessorAppIds,
+}
+
+impl ValenceWorkerTomlSerde for EthereumStrategyConfig {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EthereumDenoms {
+    /// e.g. WBTC ERC20 address
+    pub deposit_token: Address,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EthereumAccounts {
+    /// deposit account where user deposits will settle
+    /// until being IBC-Eureka'd out to Cosmos Hub
+    pub deposit: Address,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EthereumLibraries {
+    /// ERC-4626-based vault
+    pub one_way_vault: Address,
+    /// IBC-Eureka transfer
+    pub eureka_transfer: Address,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EthereumCoprocessorAppIds {
+    /// IBC Eureka
+    pub ibc_eureka: String,
+}

--- a/strategies/wbtc/types/src/gaia_config.rs
+++ b/strategies/wbtc/types/src/gaia_config.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GaiaStrategyConfig {
+    pub grpc_url: String,
+    pub grpc_port: String,
+    pub chain_id: String,
+    // native chain denom
+    pub chain_denom: String,
+
+    // deposit denom routed from ethereum via IBC-Eureka
+    pub deposit_denom: String,
+    // ICA address
+    pub ica_address: String,
+}
+
+impl ValenceWorkerTomlSerde for GaiaStrategyConfig {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GaiaDenoms {
+    /// e.g. WBTC
+    pub deposit_token: String,
+    /// gas fee denom
+    pub atom: String,
+}

--- a/strategies/wbtc/types/src/labels.rs
+++ b/strategies/wbtc/types/src/labels.rs
@@ -1,0 +1,10 @@
+pub const ICA_TRANSFER_LABEL: &str = "ica_transfer";
+pub const LEND_AND_PROVIDE_LIQUIDITY_PHASE1_LABEL: &str = "lend_and_provide_liquidity_phase1";
+pub const LEND_AND_PROVIDE_LIQUIDITY_PHASE2_LABEL: &str = "lend_and_provide_liquidity_phase2";
+pub const MARS_WITHDRAW_LABEL: &str = "mars_withdraw";
+pub const SETTLE_OBLIGATION_LABEL: &str = "settle_obligation";
+pub const REGISTER_OBLIGATION_LABEL: &str = "register_obligation";
+pub const PHASE_SHIFT_STEP1_LABEL: &str = "phase_shift_step1";
+pub const PHASE_SHIFT_STEP2_LABEL: &str = "phase_shift_step2";
+pub const PHASE_SHIFT_STEP3_LABEL: &str = "phase_shift_step3";
+pub const PHASE_SHIFT_STEP4_LABEL: &str = "phase_shift_step4";

--- a/strategies/wbtc/types/src/lib.rs
+++ b/strategies/wbtc/types/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod coprocessor_config;
+pub mod ethereum_config;
+pub mod gaia_config;
+pub mod labels;
+pub mod neutron_config;
+pub mod strategy_config;

--- a/strategies/wbtc/types/src/neutron_config.rs
+++ b/strategies/wbtc/types/src/neutron_config.rs
@@ -1,0 +1,116 @@
+use cosmwasm_std::Uint128;
+use serde::{Deserialize, Serialize};
+use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeutronStrategyConfig {
+    /// grpc node url
+    pub grpc_url: String,
+    /// grpc node port
+    pub grpc_port: String,
+    /// neutron chain id
+    pub chain_id: String,
+    /// total amount of untrn required to initiate an ibc transfer from neutron
+    pub min_ibc_fee: Uint128,
+
+    /// Mars protocol wbtc contract
+    pub mars_pool: String,
+    /// Supervaults vault addresses
+    pub fbtc_supervault: String,
+    pub lbtc_supervault: String,
+    pub solvbtc_supervault: String,
+    pub ebtc_supervault: String,
+    pub pumpbtc_supervault: String,
+    pub bedrock_supervault: String,
+    pub maxbtc_supervault: String,
+    /// authorizations module
+    pub authorizations: String,
+    /// processor coupled with the authorizations
+    pub processor: String,
+
+    /// all denoms relevant to the neutron-side of strategy
+    pub denoms: NeutronDenoms,
+    /// all accounts relevant to the neutron-side of strategy
+    pub accounts: NeutronAccounts,
+    /// all libraries relevant to the neutron-side of strategy
+    pub libraries: NeutronLibraries,
+    /// All IDs of the coprocessor apps
+    pub coprocessor_app_ids: NeutronCoprocessorAppIds,
+}
+
+impl ValenceWorkerTomlSerde for NeutronStrategyConfig {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeutronDenoms {
+    /// e.g. WBTC
+    pub deposit_token: String,
+    /// gas fee denom
+    pub ntrn: String,
+    /// supervaults LP share denoms (These need to be updated post migration)
+    pub fbtc_supervault_lp: String,
+    pub lbtc_supervault_lp: String,
+    pub solvbtc_supervault_lp: String,
+    pub ebtc_supervault_lp: String,
+    pub pumpbtc_supervault_lp: String,
+    pub bedrock_supervault_lp: String,
+    pub maxbtc_supervault_lp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeutronAccounts {
+    /// Valence ICA
+    pub ica: String,
+    /// deposit account where funds will arrive from cosmos hub
+    pub deposit: String,
+    /// input account from which funds will be deposited into Mars
+    pub mars_deposit: String,
+    /// input accounts for all supervaults
+    pub fbtc_supervault_deposit: String,
+    pub lbtc_supervault_deposit: String,
+    pub solvbtc_supervault_deposit: String,
+    pub ebtc_supervault_deposit: String,
+    pub pumpbtc_supervault_deposit: String,
+    pub bedrock_supervault_deposit: String,
+    pub maxbtc_supervault_deposit: String,
+    /// settlement account where funds will be sent to end users
+    pub settlement: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeutronLibraries {
+    /// Deposit splitter where funds will be moved from deposit account to both Mars deposit or Supervault deposit according to the split ratio
+    pub deposit_splitter: String,
+    /// Mars lending library
+    pub mars_lending: String,
+    /// Supervault lpers
+    pub fbtc_supervault_lper: String,
+    pub lbtc_supervault_lper: String,
+    pub solvbtc_supervault_lper: String,
+    pub ebtc_supervault_lper: String,
+    pub pumpbtc_supervault_lper: String,
+    pub bedrock_supervault_lper: String,
+    pub maxbtc_supervault_lper: String,
+    /// Clearing queue
+    pub clearing_queue: String,
+    /// ICA transfer library
+    pub ica_transfer: String,
+    /// phase shift maxBTC issuer library
+    pub phase_shift_maxbtc_issuer: String,
+    /// phase shift splitter
+    pub phase_shift_splitter: String,
+    /// phase shift forwarder
+    pub phase_shift_forwarder: String,
+    /// phase shift supervault withdrawers
+    pub phase_shift_fbtc_supervault_withdrawer: String,
+    pub phase_shift_lbtc_supervault_withdrawer: String,
+    pub phase_shift_solvbtc_supervault_withdrawer: String,
+    pub phase_shift_ebtc_supervault_withdrawer: String,
+    pub phase_shift_pumpbtc_supervault_withdrawer: String,
+    pub phase_shift_bedrock_supervault_withdrawer: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeutronCoprocessorAppIds {
+    /// Clearing queue
+    pub clearing_queue: String,
+}

--- a/strategies/wbtc/types/src/neutron_config.rs
+++ b/strategies/wbtc/types/src/neutron_config.rs
@@ -21,7 +21,7 @@ pub struct NeutronStrategyConfig {
     pub solvbtc_supervault: String,
     pub ebtc_supervault: String,
     pub pumpbtc_supervault: String,
-    pub bedrock_supervault: String,
+    pub bedrockbtc_supervault: String,
     pub maxbtc_supervault: String,
     /// authorizations module
     pub authorizations: String,
@@ -52,7 +52,7 @@ pub struct NeutronDenoms {
     pub solvbtc_supervault_lp: String,
     pub ebtc_supervault_lp: String,
     pub pumpbtc_supervault_lp: String,
-    pub bedrock_supervault_lp: String,
+    pub bedrockbtc_supervault_lp: String,
     pub maxbtc_supervault_lp: String,
 }
 
@@ -70,7 +70,7 @@ pub struct NeutronAccounts {
     pub solvbtc_supervault_deposit: String,
     pub ebtc_supervault_deposit: String,
     pub pumpbtc_supervault_deposit: String,
-    pub bedrock_supervault_deposit: String,
+    pub bedrockbtc_supervault_deposit: String,
     pub maxbtc_supervault_deposit: String,
     /// settlement account where funds will be sent to end users
     pub settlement: String,
@@ -88,7 +88,7 @@ pub struct NeutronLibraries {
     pub solvbtc_supervault_lper: String,
     pub ebtc_supervault_lper: String,
     pub pumpbtc_supervault_lper: String,
-    pub bedrock_supervault_lper: String,
+    pub bedrockbtc_supervault_lper: String,
     pub maxbtc_supervault_lper: String,
     /// Clearing queue
     pub clearing_queue: String,
@@ -106,7 +106,7 @@ pub struct NeutronLibraries {
     pub phase_shift_solvbtc_supervault_withdrawer: String,
     pub phase_shift_ebtc_supervault_withdrawer: String,
     pub phase_shift_pumpbtc_supervault_withdrawer: String,
-    pub phase_shift_bedrock_supervault_withdrawer: String,
+    pub phase_shift_bedrockbtc_supervault_withdrawer: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/strategies/wbtc/types/src/strategy_config.rs
+++ b/strategies/wbtc/types/src/strategy_config.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ethereum_config::EthereumStrategyConfig, gaia_config::GaiaStrategyConfig,
+    neutron_config::NeutronStrategyConfig,
+};
+
+/// top-level config that wraps around each domain configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StrategyConfig {
+    pub ethereum: EthereumStrategyConfig,
+    pub neutron: NeutronStrategyConfig,
+    pub gaia: GaiaStrategyConfig,
+}

--- a/strategies/wbtc_test/deploy/README.md
+++ b/strategies/wbtc_test/deploy/README.md
@@ -1,6 +1,6 @@
 # Deploy instructions
 
-1. If the wasm blobs are not uploaded, run the `neutron_upload.rs` script which will upload all contracts in /packages/src/contracts/cw and output the code ids in `neutron_code_ids.toml`. These file will be used to instantiate the file.
+1. If the wasm blobs are not uploaded, run the `neutron_upload.rs` script which will upload all contracts in /packages/src/contracts/cw and output the code ids in `neutron_code_ids.toml`. This file will be used to instantiate the contracts.
 
 2. Fill in all the information in `neutron.toml` except the coprocessor app fields at the end and run the `neutron_deploy.rs` script which will instantiate all the contracts, trigger the ICA creation and output all relevant addresses in `neutron_strategy_config.toml` and `gaia_strategy_config.toml` which will be used by the strategist.
 

--- a/strategies/wbtc_test/deploy/src/bin/ethereum_deploy.rs
+++ b/strategies/wbtc_test/deploy/src/bin/ethereum_deploy.rs
@@ -236,6 +236,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     sol!(
         struct IBCEurekaTransferConfig {
             uint256 amount;
+            uint256 minAmountOut;
             address transferToken;
             address inputAccount;
             string recipient;
@@ -246,7 +247,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     let eureka_transfer_config = IBCEurekaTransferConfig {
-        amount: U256::ZERO, // Full amount
+        amount: U256::ZERO,       // Full amount
+        minAmountOut: U256::ZERO, // No minimum amount out
         transferToken: parameters.vault.deposit_token,
         inputAccount: deposit_account,
         recipient: parameters.eureka_transfer.recipient,

--- a/strategies/wbtc_test/deploy/src/bin/ethereum_initialization.rs
+++ b/strategies/wbtc_test/deploy/src/bin/ethereum_initialization.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     eth_client.sign_and_send(tx).await?;
     println!("Authorization created successfully");
 
-    // TODO: Keep the ownership fo the authorization contract for now but we should transfer it eventually
+    // TODO: Keep the ownership of the authorization contract for now but we should transfer it eventually
 
     Ok(())
 }

--- a/strategies/wbtc_test/deploy/src/neutron.toml
+++ b/strategies/wbtc_test/deploy/src/neutron.toml
@@ -26,6 +26,5 @@ initial_split_percentage_to_supervault = 20
 # Mars, so we if we put 75 here, it means 75% of the clearing queue will be settled to Mars and 25% to Supervaults.
 initial_settlement_ratio_percentage = 80
 
-
 [coprocessor_app]
 clearing_queue_coprocessor_app_id = "f8923f9f3da06b726fbaf1a41a6a375c86ff2180f8c11a60d1f7ad90ac9b4281" # TBD after we have the app deployed


### PR DESCRIPTION
Scripts for deployment and initialization of WBTC vaults.
This one is the most complicated one by far so appreciate a thorough check of everything. 
I've divided the phase shift in 4 steps otherwise it would be come too difficult to manage.

Regarding strategist, added notes for things to take into account: new LP denoms after phase migration and one of the accounts will only be available once we move to phase 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive deployment and initialization scripts for WBTC strategy contracts on both Ethereum and Neutron blockchains.
  - Added configuration files and TOML-based templates for streamlined deployment and parameter management.
  - Provided detailed deployment and initialization instructions for strategists.
  - Implemented robust configuration structures and labels for Ethereum, Neutron, and Gaia strategies.

- **Documentation**
  - Added and improved README files with clearer deployment steps and corrected minor typos.

- **Style**
  - Fixed minor typographical errors and improved comment clarity in code and documentation.

- **Chores**
  - Updated workspace configuration to include new deployment and types packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->