### PR TITLE
dynamic split ratio update for wbtc phase shift

### DIFF
--- a/strategies/lombard_btc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/lombard_btc/deploy/src/bin/neutron_deploy.rs
@@ -47,7 +47,6 @@ struct General {
     chain_id: String,
     owner: String,
     valence_owner: String,
-    strategist: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -302,7 +301,7 @@ async fn main() -> anyhow::Result<()> {
 
     let dynamic_ratio_query_provider_instantiate_msg =
         valence_dynamic_ratio_query_provider::msg::InstantiateMsg {
-            admin: params.general.strategist,
+            admin: params.general.owner.clone(),
             split_cfg: DenomSplitMap {
                 split_cfg: denom_to_splits,
             },

--- a/strategies/lombard_btc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/lombard_btc/strategist/src/phases/obligation_registration.rs
@@ -54,7 +54,7 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "no new withdraw requests; concluding obligation registration phase...");
             return Ok(());
         }
-        info!(target: REGISTRATION_PHASE, "new_obligations = {:#?}", new_obligations);
+        info!(target: REGISTRATION_PHASE, "new_obligations = {new_obligations:#?}");
 
         // process the new OneWayVault Withdraw events in order from the oldest
         // to the newest, posting them to the coprocessor to obtain a ZKP

--- a/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
@@ -48,7 +48,6 @@ struct General {
     chain_id: String,
     owner: String,
     valence_owner: String,
-    strategist: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -362,7 +361,7 @@ async fn main() -> anyhow::Result<()> {
 
     let dynamic_ratio_query_provider_instantiate_msg =
         valence_dynamic_ratio_query_provider::msg::InstantiateMsg {
-            admin: params.general.strategist,
+            admin: params.general.owner.clone(),
             split_cfg: DenomSplitMap {
                 split_cfg: denom_to_splits,
             },
@@ -1338,6 +1337,7 @@ async fn main() -> anyhow::Result<()> {
 
     let libraries = NeutronLibraries {
         deposit_splitter: deposit_splitter_library_address,
+        dynamic_ratio_query_provider: dynamic_ratio_query_provider_address,
         mars_lending: mars_lending_library_address,
         clearing_queue: clearing_queue_library_address,
         ica_transfer: ica_ibc_transfer_library_address,

--- a/strategies/wbtc/deploy/src/bin/neutron_initialization.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_initialization.rs
@@ -700,6 +700,7 @@ async fn main() -> anyhow::Result<()> {
     // AUTHORIZATION 4 - STEPS:
     // 1) Update the new split config to use the new phase 2 ratios
     // 2) Update the clearing queue config to use the new settlement ratios
+    // 3) Update the dynamic ratio query provide to use the new split ratios
     let update_splitter_function = AtomicFunction {
         domain: Domain::Main,
         message_details: MessageDetails {
@@ -741,10 +742,27 @@ async fn main() -> anyhow::Result<()> {
             ntrn_strategy_config.libraries.clearing_queue.clone(),
         ),
     };
+    let update_dynamic_ratio_query_provider_function = AtomicFunction {
+        domain: Domain::Main,
+        message_details: MessageDetails {
+            message_type: MessageType::CosmwasmExecuteMsg,
+            message: Message {
+                name: "update_ratios".to_string(),
+                params_restrictions: None,
+            },
+        },
+        contract_address: LibraryAccountType::Addr(
+            ntrn_strategy_config
+                .libraries
+                .dynamic_ratio_query_provider
+                .clone(),
+        ),
+    };
 
     let subroutine_phase_shift_step4 = AtomicSubroutineBuilder::new()
         .with_function(update_splitter_function)
         .with_function(update_clearing_queue_function)
+        .with_function(update_dynamic_ratio_query_provider_function)
         .build();
     let authorization_phase_shift_step4 = AuthorizationBuilder::new()
         .with_label(PHASE_SHIFT_STEP4_LABEL)

--- a/strategies/wbtc/types/src/neutron_config.rs
+++ b/strategies/wbtc/types/src/neutron_config.rs
@@ -80,6 +80,8 @@ pub struct NeutronAccounts {
 pub struct NeutronLibraries {
     /// Deposit splitter where funds will be moved from deposit account to both Mars deposit or Supervault deposit according to the split ratio
     pub deposit_splitter: String,
+    /// Dynamic ratio query provider
+    pub dynamic_ratio_query_provider: String,
     /// Mars lending library
     pub mars_lending: String,
     /// Supervault lpers

--- a/strategies/wbtc_test/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/wbtc_test/deploy/src/bin/neutron_deploy.rs
@@ -47,7 +47,6 @@ struct General {
     chain_id: String,
     owner: String,
     valence_owner: String,
-    strategist: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -302,7 +301,7 @@ async fn main() -> anyhow::Result<()> {
 
     let dynamic_ratio_query_provider_instantiate_msg =
         valence_dynamic_ratio_query_provider::msg::InstantiateMsg {
-            admin: params.general.strategist,
+            admin: params.general.owner.clone(),
             split_cfg: DenomSplitMap {
                 split_cfg: denom_to_splits,
             },


### PR DESCRIPTION
made the program owner the owner of the dynamic split ratio update because it will need to be updated during phase shift.

It at some point they just want to transfer ownership to strategist they can do it eventually.