### PR TITLE
chore: remove min ibc fee param from Neutron strategy configs

### DIFF
--- a/strategies/btc_lst/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/btc_lst/deploy/src/bin/neutron_deploy.rs
@@ -646,7 +646,6 @@ async fn main() -> anyhow::Result<()> {
         denoms,
         accounts,
         libraries,
-        min_ibc_fee: Uint128::one(),
         authorizations: authorization_address,
         processor: processor_address,
         coprocessor_app_ids,

--- a/strategies/btc_lst/types/src/neutron_config.rs
+++ b/strategies/btc_lst/types/src/neutron_config.rs
@@ -1,4 +1,3 @@
-use cosmwasm_std::Uint128;
 use serde::{Deserialize, Serialize};
 use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
 
@@ -10,8 +9,6 @@ pub struct NeutronStrategyConfig {
     pub grpc_port: String,
     /// neutron chain id
     pub chain_id: String,
-    /// total amount of untrn required to initiate an ibc transfer from neutron
-    pub min_ibc_fee: Uint128,
 
     /// Mars credit manager
     pub mars_credit_manager: String,

--- a/strategies/cctp_lend/deploy/src/artifacts/neutron_strategy_config.toml
+++ b/strategies/cctp_lend/deploy/src/artifacts/neutron_strategy_config.toml
@@ -1,7 +1,6 @@
 grpc_url = "http://rpc.neutron.quokkastake.io"
 grpc_port = "9090"
 chain_id = "neutron-1"
-min_ibc_fee = "1"
 mars_credit_manager = "neutron1scjuh29rzffqzhgxusjd56f7qnf7r9e6rwxym6n65h9d3kkhfrqs0xm4dn"
 authorizations = "neutron1x63lhjd9et48ct6hygd2l03u27c4j409d0cw8tzxmau3yw0u8f6ql4usk6"
 processor = "neutron1tdpj4tjjvs32q670w460xmlf0zzlcfmvaaz5arej7yy47utaxdvquvzk63"

--- a/strategies/cctp_lend/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/cctp_lend/deploy/src/bin/neutron_deploy.rs
@@ -8,7 +8,7 @@ use cctp_lend_types::{
     },
     noble_config::NobleStrategyConfig,
 };
-use cosmwasm_std::{Decimal, Uint128};
+use cosmwasm_std::Decimal;
 use packages::{
     contracts::{PATH_NEUTRON_CODE_IDS, UploadedContracts},
     types::inputs::{ChainClientInputs, ClearingQueueCoprocessorApp},
@@ -273,7 +273,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         denoms,
         accounts,
         libraries,
-        min_ibc_fee: Uint128::one(),
         authorizations: authorization_address,
         processor: processor_address,
         coprocessor_app_ids,

--- a/strategies/cctp_lend/types/src/neutron_config.rs
+++ b/strategies/cctp_lend/types/src/neutron_config.rs
@@ -1,4 +1,3 @@
-use cosmwasm_std::Uint128;
 use serde::{Deserialize, Serialize};
 use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
 
@@ -10,8 +9,6 @@ pub struct NeutronStrategyConfig {
     pub grpc_port: String,
     /// neutron chain id
     pub chain_id: String,
-    /// total amount of untrn required to initiate an ibc transfer from neutron
-    pub min_ibc_fee: Uint128,
 
     /// Mars credit manager
     pub mars_credit_manager: String,

--- a/strategies/lombard_btc/deploy/src/artifacts/neutron_strategy_config.toml
+++ b/strategies/lombard_btc/deploy/src/artifacts/neutron_strategy_config.toml
@@ -1,7 +1,6 @@
 grpc_url            = "http://rpc.neutron.quokkastake.io"
 grpc_port           = "9090"
 chain_id            = "neutron-1"
-min_ibc_fee         = "1"
 mars_credit_manager = "neutron1scjuh29rzffqzhgxusjd56f7qnf7r9e6rwxym6n65h9d3kkhfrqs0xm4dn"
 supervault          = "neutron1720ank30032ml4h6rsygv0j9q4kdg9yr5g57yn55rmw3mnstg24q2keq2y"
 authorizations      = "neutron1692gg6kcpa8vez604ajycfz28033vajmnfncf3dga562vxldk4nsq0fryd"

--- a/strategies/lombard_btc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/lombard_btc/deploy/src/bin/neutron_deploy.rs
@@ -647,7 +647,6 @@ async fn main() -> anyhow::Result<()> {
         denoms,
         accounts,
         libraries,
-        min_ibc_fee: Uint128::one(),
         authorizations: authorization_address,
         processor: processor_address,
         coprocessor_app_ids,

--- a/strategies/lombard_btc/types/src/neutron_config.rs
+++ b/strategies/lombard_btc/types/src/neutron_config.rs
@@ -1,4 +1,3 @@
-use cosmwasm_std::Uint128;
 use serde::{Deserialize, Serialize};
 use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
 
@@ -10,8 +9,6 @@ pub struct NeutronStrategyConfig {
     pub grpc_port: String,
     /// neutron chain id
     pub chain_id: String,
-    /// total amount of untrn required to initiate an ibc transfer from neutron
-    pub min_ibc_fee: Uint128,
 
     /// Mars credit manager
     pub mars_credit_manager: String,

--- a/strategies/usdc/deploy/src/artifacts/neutron_strategy_config.toml
+++ b/strategies/usdc/deploy/src/artifacts/neutron_strategy_config.toml
@@ -1,7 +1,6 @@
 grpc_url       = "http://rpc.neutron.quokkastake.io"
 grpc_port      = "9090"
 chain_id       = "neutron-1"
-min_ibc_fee    = "1"
 supervault     = "neutron1z4qky902yes9zl5eruwgdd2pgtlyeglunc0escf0a7n2xeyw97gqcr7u5u"
 authorizations = "neutron17galwl0670q5vrvfsuxu9zsnhut45p90ml75nucz73qp38hv7yyqyga83d"
 processor      = "neutron1gdz93w34jwg69xwygf8m7202aguev93ygejy2duuvz2zd7m3sq6sktg7kk"

--- a/strategies/usdc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/usdc/deploy/src/bin/neutron_deploy.rs
@@ -1,6 +1,6 @@
 use std::{env, error::Error, fs, time::SystemTime};
 
-use cosmwasm_std::{Decimal, Uint128};
+use cosmwasm_std::Decimal;
 use packages::{
     contracts::{PATH_NEUTRON_CODE_IDS, UploadedContracts},
     types::inputs::{ChainClientInputs, ClearingQueueCoprocessorApp},
@@ -289,7 +289,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         denoms,
         accounts,
         libraries,
-        min_ibc_fee: Uint128::one(),
         authorizations: authorization_address,
         processor: processor_address,
         coprocessor_app_ids,

--- a/strategies/usdc/types/src/neutron_config.rs
+++ b/strategies/usdc/types/src/neutron_config.rs
@@ -1,4 +1,3 @@
-use cosmwasm_std::Uint128;
 use serde::{Deserialize, Serialize};
 use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
 
@@ -10,8 +9,6 @@ pub struct NeutronStrategyConfig {
     pub grpc_port: String,
     /// neutron chain id
     pub chain_id: String,
-    /// total amount of untrn required to initiate an ibc transfer from neutron
-    pub min_ibc_fee: Uint128,
 
     /// Supervaults vault address
     pub supervault: String,

--- a/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/wbtc/deploy/src/bin/neutron_deploy.rs
@@ -1345,7 +1345,6 @@ async fn main() -> anyhow::Result<()> {
         denoms,
         accounts,
         libraries,
-        min_ibc_fee: Uint128::one(),
         authorizations: authorization_address,
         processor: processor_address,
         coprocessor_app_ids,

--- a/strategies/wbtc/types/src/neutron_config.rs
+++ b/strategies/wbtc/types/src/neutron_config.rs
@@ -1,4 +1,3 @@
-use cosmwasm_std::Uint128;
 use serde::{Deserialize, Serialize};
 use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
 
@@ -10,8 +9,6 @@ pub struct NeutronStrategyConfig {
     pub grpc_port: String,
     /// neutron chain id
     pub chain_id: String,
-    /// total amount of untrn required to initiate an ibc transfer from neutron
-    pub min_ibc_fee: Uint128,
 
     /// Mars protocol credit manager
     pub mars_credit_manager: String,


### PR DESCRIPTION
# Description

Removes the unused `min_ibc_fee` field from `NeutronStrategyConfig` (from all applicable strategies).

Manually patches the existing deployment artifacts, removing that field.