### PR TITLE
feat: maxbtc mint vault strategist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,6 +4831,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "maxbtc_mint_strategist"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "async-trait",
+ "cosmwasm-std",
+ "dotenv",
+ "env_logger",
+ "hex",
+ "log",
+ "maxbtc_mint_types",
+ "mmvault 0.1.6 (git+https://github.com/neutron-org/slinky-vault?rev=b2e2ff4)",
+ "packages",
+ "serde",
+ "serde_json",
+ "tokio",
+ "valence-account-utils",
+ "valence-authorization-utils",
+ "valence-clearing-queue-supervaults",
+ "valence-domain-clients",
+ "valence-ica-ibc-transfer",
+ "valence-lending-utils",
+ "valence-library-utils",
+ "valence-maxbtc-issuer",
+ "valence-processor-utils",
+ "valence-strategist-utils",
+]
+
+[[package]]
 name = "maxbtc_mint_types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "strategies/btc_lst/strategist",
   "strategies/btc_lst/types",
   "strategies/maxbtc_mint/deploy",
+  "strategies/maxbtc_mint/strategist",
   "strategies/maxbtc_mint/types",
   "coprocessor-apps/clearing-queue/circuit",
   "coprocessor-apps/clearing-queue/controller",

--- a/packages/src/utils/maxbtc.rs
+++ b/packages/src/utils/maxbtc.rs
@@ -1,0 +1,11 @@
+use valence_domain_clients::clients::neutron::NeutronClient;
+
+pub async fn query_maxbtc_exchange_amount(
+    _client: &NeutronClient,
+    _maxbtc_contract: &str,
+    _amount: u128,
+) -> anyhow::Result<u128> {
+    // TODO: Implement the logic to query how much maxBTC we would get for depositing a certain amount into the maxBTC contract
+    // This query is not available yet but will be soon
+    Ok(0)
+}

--- a/packages/src/utils/mod.rs
+++ b/packages/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod logging;
 pub mod mars;
+pub mod maxbtc;
 pub mod obligation;
 pub mod skip;
 pub mod supervaults;

--- a/strategies/maxbtc_mint/deploy/src/bin/neutron_deploy.rs
+++ b/strategies/maxbtc_mint/deploy/src/bin/neutron_deploy.rs
@@ -245,10 +245,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Instantiate the clearing queue library
     // We are going to reuse the same clearing library even though we are not using mars nor supervaults
-    // We just need to payout everything in 1 denom from the settlement account, and this works.
+    // We just need to payout everything in 1 denom (maxBTC) from the settlement account, and this works.
     let clearing_config = valence_clearing_queue_supervaults::msg::LibraryConfig {
         settlement_acc_addr: LibraryAccountType::Addr(predicted_base_accounts[1].clone()),
-        denom: params.program.deposit_token_on_neutron_denom.clone(),
+        denom: params.program.maxbtc_denom.clone(),
         latest_id: None,
         mars_settlement_ratio: Decimal::percent(100),
         supervaults_settlement_info: vec![],

--- a/strategies/maxbtc_mint/deploy/src/inputs/ethereum.toml
+++ b/strategies/maxbtc_mint/deploy/src/inputs/ethereum.toml
@@ -14,7 +14,7 @@ deposit_fee_bps          = 100                                          # 1% dep
 withdraw_fee_bps         = 100                                          # 1% withdraw fee
 max_rate_increment_bps   = 2000                                         # 20% maximum rate increment per update
 max_rate_decrement_bps   = 2000                                         # 20% maximum rate decrement per update
-starting_rate            = "100000000"                                  # 1e8 - bitcoin LST precision - 8 decimals
+starting_rate            = "100000000"                                  # Should be the maxBTC rate for the deposit token
 min_rate_update_delay    = 300                                          # 5 minutes - Minimum delay for rate updates - for testing purposes      
 max_rate_update_delay    = 345600                                       # 4 days in seconds - Maximum delay for rate updates before vault gets paused
 

--- a/strategies/maxbtc_mint/strategist/Cargo.toml
+++ b/strategies/maxbtc_mint/strategist/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name    = "maxbtc_mint_strategist"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow                             = { workspace = true }
+maxbtc_mint_types                  = { path = "../types" }
+packages                           = { path = "../../../packages" }
+dotenv                             = { workspace = true }
+cosmwasm-std                       = { workspace = true }
+serde                              = { workspace = true }
+valence-domain-clients             = { workspace = true }
+alloy                              = { workspace = true }
+hex                                = { workspace = true }
+valence-authorization-utils        = { workspace = true }
+valence-processor-utils            = { workspace = true }
+valence-library-utils              = { workspace = true }
+valence-account-utils              = { workspace = true }
+valence-ica-ibc-transfer           = { workspace = true }
+valence-clearing-queue-supervaults = { workspace = true }
+valence-strategist-utils           = { workspace = true }
+valence-maxbtc-issuer              = { workspace = true }
+log                                = { workspace = true }
+env_logger                         = { workspace = true }
+async-trait                        = { workspace = true }
+valence-lending-utils              = { workspace = true }
+mmvault                            = { workspace = true }
+serde_json                         = { workspace = true }
+tokio                              = { workspace = true }

--- a/strategies/maxbtc_mint/strategist/maxbtc_mint.example.env
+++ b/strategies/maxbtc_mint/strategist/maxbtc_mint.example.env
@@ -1,0 +1,23 @@
+# domain-specific config paths
+NEUTRON_CFG_PATH=./strategies/maxbtc_mint/deploy/src/artifacts/neutron_strategy_config.toml
+ETHEREUM_CFG_PATH=./strategies/maxbtc_mint/deploy/src/artifacts/ethereum_strategy_config.toml
+GAIA_CFG_PATH=./strategies/maxbtc_mint/deploy/src/artifacts/gaia_strategy_config.toml
+
+# strategist mnemonic
+MNEMONIC="todo"
+
+# strategy label (name)
+LABEL="X_MAXBTC_MINT"
+
+# period between cycles, in seconds
+STRATEGY_TIMEOUT="30"
+
+# valence indexer url and key
+INDEXER_API_KEY=""
+INDEXER_API_URL=""
+
+# ibc eureka api config
+EUREKA_API_URL="https://go.skip.build/api/skip/v2/fungible/route"
+
+# logging endpoint
+OTLP_ENDPOINT=""

--- a/strategies/maxbtc_mint/strategist/src/bin/runner.rs
+++ b/strategies/maxbtc_mint/strategist/src/bin/runner.rs
@@ -1,0 +1,49 @@
+use log::{info, warn};
+use maxbtc_mint_strategist::strategy_config::Strategy;
+use packages::utils::logging::setup_logging;
+use std::env;
+use valence_strategist_utils::worker::ValenceWorker;
+
+const RUNNER: &str = "runner";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // load environment variables
+    let env_path = env::current_dir()?.join("strategies/maxbtc_mint/strategist/maxbtc_mint.env");
+    dotenv::from_path(env_path.as_path())?;
+
+    setup_logging().await?;
+
+    info!(target: RUNNER, "starting the strategist runner");
+
+    // get configuration paths from environment variables
+    let neutron_cfg_path = env::var("NEUTRON_CFG_PATH")
+        .map_err(|e| anyhow::Error::msg(format!("neutron cfg path not found: {e}")))?;
+    let ethereum_cfg_path = env::var("ETHEREUM_CFG_PATH")
+        .map_err(|e| anyhow::Error::msg(format!("eth cfg path not found: {e}")))?;
+    let gaia_cfg_path = env::var("GAIA_CFG_PATH")
+        .map_err(|e| anyhow::Error::msg(format!("gaia cfg path not found: {e}")))?;
+
+    info!(target: RUNNER, "Using configuration files:");
+    info!(target: RUNNER, "  Neutron: {neutron_cfg_path}");
+    info!(target: RUNNER, "  Ethereum: {ethereum_cfg_path}");
+    info!(target: RUNNER, "  Gaia: {gaia_cfg_path}");
+
+    // initialize the strategy from configuration files
+    let strategy =
+        Strategy::from_files(&neutron_cfg_path, &gaia_cfg_path, &ethereum_cfg_path).await?;
+
+    info!(target: RUNNER, "strategy initialized");
+    info!(target: RUNNER, "starting the strategist");
+
+    // start the strategy and get the thread join handle
+    let strategist_join_handle = strategy.start();
+
+    // join here will wait for the strategist thread to finish which should never happen in practice since it runs an infinite stayalive loop
+    match strategist_join_handle.join() {
+        Ok(t) => warn!(target: RUNNER, "strategist thread completed: {t:?}"),
+        Err(e) => warn!(target: RUNNER, "strategist thread completed with error: {e:?}"),
+    }
+
+    Ok(())
+}

--- a/strategies/maxbtc_mint/strategist/src/lib.rs
+++ b/strategies/maxbtc_mint/strategist/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod phases;
+pub mod strategist;
+pub mod strategy_config;

--- a/strategies/maxbtc_mint/strategist/src/phases/deposit.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/deposit.rs
@@ -1,0 +1,304 @@
+use alloy::{
+    primitives::{Bytes, U256},
+    providers::Provider,
+};
+
+use cosmwasm_std::to_json_binary;
+use log::{info, warn};
+use packages::{
+    labels::{ICA_TRANSFER_LABEL, MAXBTC_ISSUE_LABEL},
+    phases::DEPOSIT_PHASE,
+    types::sol_types::{Authorization, BaseAccount, ERC20},
+    utils::{self, valence_core},
+};
+use serde_json::json;
+use valence_domain_clients::{
+    coprocessor::base_client::CoprocessorBaseClient,
+    cosmos::base_client::BaseClient,
+    evm::base_client::{CustomProvider, EvmBaseClient},
+};
+use valence_library_utils::OptionUpdate;
+
+use crate::strategy_config::Strategy;
+
+impl Strategy {
+    /// carries out the steps needed to bring the new deposits from Ethereum to
+    /// Neutron (via Cosmos Hub) before minting the maxBTC.
+    /// consists of three stages:
+    /// 1. Ethereum -> Hub routing
+    /// 2. Hub -> Neutron routing
+    /// 3. maxBTC issuing
+    pub async fn deposit(&mut self, eth_rp: &CustomProvider) -> anyhow::Result<()> {
+        info!(target: DEPOSIT_PHASE, "starting deposit phase");
+
+        // Stage 1: deposit token routing from Ethereum to Cosmos hub
+        {
+            let eth_deposit_token_contract =
+                ERC20::new(self.cfg.ethereum.denoms.deposit_token, &eth_rp);
+            let eth_deposit_acc = BaseAccount::new(self.cfg.ethereum.accounts.deposit, &eth_rp);
+
+            // query the ethereum deposit account balance
+            let eth_deposit_acc_bal = self
+                .eth_client
+                .query(eth_deposit_token_contract.balanceOf(*eth_deposit_acc.address()))
+                .await?
+                ._0;
+            info!(target: DEPOSIT_PHASE, "eth deposit acc balance = {eth_deposit_acc_bal}");
+
+            // validate that the deposit account balance exceeds the eureka routing
+            // threshold amount
+            if eth_deposit_acc_bal < self.cfg.ethereum.ibc_transfer_threshold_amt {
+                // if balance does not exceed the transfer threshold, we skip the eureka transfer steps
+                // and proceed to gaia ica -> neutron routing
+                info!(target: DEPOSIT_PHASE, "IBC-Eureka transfer threshold not met! Proceeding to ICA routing.");
+            } else {
+                // if balance meets the transfer threshold, we carry out the eureka transfer steps
+                // prior to proceeding to gaia ica -> neutron routing
+                info!(target: DEPOSIT_PHASE, "IBC-Eureka transfer threshold met!");
+
+                self.eth_to_gaia_routing(eth_rp, eth_deposit_acc_bal)
+                    .await?;
+            }
+        }
+
+        // Stage 2: deposit token routing from Gaia to Neutron
+        {
+            let gaia_ica_bal = self
+                .gaia_client
+                .query_balance(&self.cfg.gaia.ica_address, &self.cfg.gaia.deposit_denom)
+                .await?;
+            info!(target: DEPOSIT_PHASE, "Cosmos Hub ICA balance = {gaia_ica_bal}");
+
+            // depending on the gaia ICA deposit token balance, we either perform the ICA IBC routing
+            // of the balances to Neutron, or proceed to the next stage
+            if gaia_ica_bal == 0 {
+                info!(target: DEPOSIT_PHASE, "nothing to bridge; proceeding to position entry");
+            } else {
+                info!(target: DEPOSIT_PHASE, "pulling funds to Neutron...");
+                self.gaia_to_neutron_routing(gaia_ica_bal).await?;
+            }
+        }
+
+        // Stage 3: maxBTC issuance
+        {
+            let neutron_deposit_bal = self
+                .neutron_client
+                .query_balance(
+                    &self.cfg.neutron.accounts.deposit,
+                    &self.cfg.neutron.denoms.deposit_token,
+                )
+                .await?;
+            info!(target: DEPOSIT_PHASE, "Neutron deposit account balance = {neutron_deposit_bal}");
+
+            // if there is something in the Neutron deposit account, we trigger the maxBTC issuance
+            if neutron_deposit_bal > 0 {
+                info!(target: DEPOSIT_PHASE, "Neutron deposit account balance = {neutron_deposit_bal}; triggering maxBTC issuance...");
+                self.issue_maxbtc().await?;
+            } else {
+                info!(target: DEPOSIT_PHASE, "Neutron deposit account balance is zero, skipping...");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// performs one action:
+    ///    mints maxBTC on Neutron by sending the deposit token from the
+    ///    Neutron deposit account to the maxBTC contract
+    async fn issue_maxbtc(&mut self) -> anyhow::Result<()> {
+        // use Splitter to route funds from the Neutron program deposit
+        // account to the Mars and Supervaults deposit accounts
+        let maxbtc_issue_msg = valence_library_utils::msg::ExecuteMsg::<_, ()>::ProcessFunction(
+            valence_maxbtc_issuer::msg::FunctionMsgs::Issue {},
+        );
+
+        // enqueue the function
+        valence_core::enqueue_neutron(
+            &self.neutron_client,
+            &self.cfg.neutron.authorizations,
+            MAXBTC_ISSUE_LABEL,
+            vec![to_json_binary(&maxbtc_issue_msg)?],
+        )
+        .await?;
+
+        valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
+
+        Ok(())
+    }
+
+    /// carries out the steps needed to route the deposits from Ethereum program deposit
+    /// account to the configured Cosmos Hub ICA managed by Neutron Valence-ICA.
+    async fn eth_to_gaia_routing(
+        &mut self,
+        eth_rp: &CustomProvider,
+        eth_deposit_acc_bal: U256,
+    ) -> anyhow::Result<()> {
+        let eth_auth_contract = Authorization::new(self.cfg.ethereum.authorizations, &eth_rp);
+
+        // fetch the IBC-Eureka route from eureka client
+        let skip_api_response = match self
+            .ibc_eureka_client
+            .query_skip_eureka_route(eth_deposit_acc_bal.to_string())
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(target: DEPOSIT_PHASE, "skip route error: {e}");
+                return Ok(());
+            }
+        };
+
+        let post_fee_amount_out_u128 = utils::skip::get_amount_out(&skip_api_response)?;
+        info!(target: DEPOSIT_PHASE, "post_fee_amount_out_u128 = {post_fee_amount_out_u128:?}" );
+
+        // format the response in format expected by the coprocessor and post it
+        // there for proof
+        let coprocessor_input = json!({"skip_response": skip_api_response});
+
+        info!(target: DEPOSIT_PHASE, "co-processor input: {coprocessor_input}");
+        info!(
+            target: DEPOSIT_PHASE,
+            "co-processor ID: {}",
+            self.cfg.ethereum.coprocessor_app_ids.ibc_eureka,
+        );
+
+        let skip_response_zkp = self
+            .coprocessor_client
+            .prove(
+                &self.cfg.ethereum.coprocessor_app_ids.ibc_eureka,
+                &coprocessor_input,
+            )
+            .await?;
+
+        info!(target: DEPOSIT_PHASE, "co_processor zkp post response: {skip_response_zkp:?}");
+
+        // extract the program and domain parameters by decoding the zkp
+        let (proof_program, inputs_program) = skip_response_zkp.program.decode()?;
+        let (proof_domain, inputs_domain) = skip_response_zkp.domain.decode()?;
+
+        // build the eureka transfer zk message from decoded params
+        let auth_eureka_transfer_zk_msg = eth_auth_contract.executeZKMessage(
+            Bytes::from(inputs_program),
+            Bytes::from(proof_program),
+            Bytes::from(inputs_domain),
+            Bytes::from(proof_domain),
+        );
+
+        // sign and execute the tx & await its tx receipt before proceeding
+        info!(target: DEPOSIT_PHASE, "posting skip-api zkp ethereum authorizations");
+        let zk_auth_exec_response = self
+            .eth_client
+            .sign_and_send(auth_eureka_transfer_zk_msg.into_transaction_request())
+            .await?;
+        eth_rp
+            .get_transaction_receipt(zk_auth_exec_response.transaction_hash)
+            .await?;
+
+        // transfer can be considered complete when the current ica balance increases
+        // by the expected post_fee ibc eureka transfer amount out
+        let pre_routing_gaia_ica_bal = self
+            .gaia_client
+            .query_balance(&self.cfg.gaia.ica_address, &self.cfg.gaia.deposit_denom)
+            .await?;
+        let gaia_ica_expected_balance = pre_routing_gaia_ica_bal + post_fee_amount_out_u128;
+        info!(
+            target: DEPOSIT_PHASE,
+            "gaia ica expected bal = {gaia_ica_expected_balance}; polling..."
+        );
+
+        // block execution until the funds arrive to the Cosmos Hub ICA owned
+        // by the Valence Interchain Account on Neutron.
+        // poll for 15sec * 100 = 1500sec = 25min which should suffice for
+        // IBC Eureka routing time of 15min
+        self.gaia_client
+            .poll_until_expected_balance(
+                &self.cfg.gaia.ica_address,
+                &self.cfg.gaia.deposit_denom,
+                gaia_ica_expected_balance,
+                15,  // every 15 sec
+                100, // for 100 times
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// carries out the steps needed to route the deposits from cosmos hub ICA to the
+    /// Neutron deposit account.
+    /// two messages are enqueued:
+    /// 1. update the ica ibc transfer library transfer amount
+    /// 2. trigger the ica ibc transfer
+    async fn gaia_to_neutron_routing(&mut self, gaia_ica_bal: u128) -> anyhow::Result<()> {
+        let ica_ibc_transfer_update_msg: valence_library_utils::msg::ExecuteMsg<
+            valence_ica_ibc_transfer::msg::FunctionMsgs,
+            valence_ica_ibc_transfer::msg::LibraryConfigUpdate,
+        > = valence_library_utils::msg::ExecuteMsg::UpdateConfig {
+            new_config: valence_ica_ibc_transfer::msg::LibraryConfigUpdate {
+                input_addr: None,
+                amount: Some(gaia_ica_bal.into()),
+                denom: None,
+                receiver: None,
+                memo: None,
+                remote_chain_info: None,
+                denom_to_pfm_map: None,
+                eureka_config: OptionUpdate::Set(None),
+            },
+        };
+        let ica_ibc_transfer_exec_msg =
+            valence_library_utils::msg::ExecuteMsg::<_, ()>::ProcessFunction(
+                valence_ica_ibc_transfer::msg::FunctionMsgs::Transfer {},
+            );
+
+        info!(target: DEPOSIT_PHASE, "enqueuing ica_ibc_transfer library update & transfer");
+        valence_core::enqueue_neutron(
+            &self.neutron_client,
+            &self.cfg.neutron.authorizations,
+            ICA_TRANSFER_LABEL,
+            vec![
+                to_json_binary(&ica_ibc_transfer_update_msg)?,
+                to_json_binary(&ica_ibc_transfer_exec_msg)?,
+            ],
+        )
+        .await?;
+
+        valence_core::ensure_neutron_account_fees_coverage(
+            &self.neutron_client,
+            &self.cfg.neutron.accounts.gaia_ica,
+        )
+        .await?;
+
+        // transfer can be considered complete when the current ica balance increases
+        // by the expected post_fee ibc eureka transfer amount out
+        let pre_routing_neutron_deposit_acc_bal = self
+            .neutron_client
+            .query_balance(
+                &self.cfg.neutron.accounts.deposit,
+                &self.cfg.neutron.denoms.deposit_token,
+            )
+            .await?;
+
+        let neutron_deposit_acc_expected_bal = pre_routing_neutron_deposit_acc_bal + gaia_ica_bal;
+        info!(
+            target: DEPOSIT_PHASE,
+            "neutron deposit acc expected bal = {neutron_deposit_acc_expected_bal}; polling..."
+        );
+
+        info!(target: DEPOSIT_PHASE, "tick: update & transfer");
+        valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
+
+        info!(target: DEPOSIT_PHASE, "polling for neutron deposit account to receive the funds");
+
+        // block execution until funds arrive to the Neutron program deposit
+        // account
+        self.neutron_client
+            .poll_until_expected_balance(
+                &self.cfg.neutron.accounts.deposit,
+                &self.cfg.neutron.denoms.deposit_token,
+                neutron_deposit_acc_expected_bal,
+                5,
+                30,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/strategies/maxbtc_mint/strategist/src/phases/mod.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/mod.rs
@@ -1,0 +1,5 @@
+pub mod deposit;
+pub mod obligation_registration;
+pub mod sentry;
+pub mod settlement;
+pub mod update;

--- a/strategies/maxbtc_mint/strategist/src/phases/obligation_registration.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/obligation_registration.rs
@@ -1,0 +1,99 @@
+use log::info;
+use packages::{phases::REGISTRATION_PHASE, utils::valence_core};
+use serde_json::json;
+use valence_domain_clients::{
+    coprocessor::base_client::CoprocessorBaseClient, cosmos::wasm_client::WasmClient,
+    indexer::one_way_vault::OneWayVaultIndexer,
+};
+
+use crate::strategy_config::Strategy;
+
+impl Strategy {
+    /// reads the newly submitted withdrawal obligations that are not yet
+    /// present in the Clearing Queue, generates their zero-knowledge proofs,
+    /// and posts them into the Clearing queue, in order.
+    /// consists of the following stages:
+    /// 1. fetching all new withdraw obligations from the indexer
+    /// 2. generating ZKP for each of the newly fetched obligations
+    /// 3. posting ZKPs to the neutron authorizations module before
+    ///    attempting to enqueue them
+    pub async fn register_withdraw_obligations(&mut self) -> anyhow::Result<()> {
+        info!(target: REGISTRATION_PHASE, "starting withdraw obligation registration phase");
+
+        // query the Clearing Queue library for the latest posted withdraw request ID
+        let clearing_queue_cfg: valence_clearing_queue_supervaults::msg::Config = self
+            .neutron_client
+            .query_contract_state(
+                &self.cfg.neutron.libraries.clearing_queue,
+                valence_clearing_queue_supervaults::msg::QueryMsg::GetLibraryConfig {},
+            )
+            .await?;
+
+        info!(
+            target: REGISTRATION_PHASE,
+            "latest_registered_obligation_id={:?}", clearing_queue_cfg.latest_id
+        );
+
+        // prepare the start_id for the indexer query. if there is no latest_id on the
+        // clearing queue config, meaning there are no obligations registered yet, we
+        // default to 0 to fetch everything. otherwise we increment the id by 1 to only
+        // fetch the new withdraw requests that have not been posted to the clearing
+        // queue yet.
+        let start_id: u64 = clearing_queue_cfg
+            .latest_id
+            .map_or(0, |id| id.u64().saturating_add(1));
+
+        // query the OneWayVault indexer to fetch all obligations that were registered
+        // on the vault but are not yet registered into the queue on Neutron
+        let new_obligations = self
+            .indexer_client
+            .query_vault_withdraw_requests(Some(start_id), true)
+            .await?;
+
+        if new_obligations.is_empty() {
+            info!(target: REGISTRATION_PHASE, "no new withdraw requests; concluding obligation registration phase...");
+            return Ok(());
+        }
+        info!(target: REGISTRATION_PHASE, "new_obligations = {new_obligations:#?}");
+
+        // process the new OneWayVault Withdraw events in order from the oldest
+        // to the newest, posting them to the coprocessor to obtain a ZKP
+        for (obligation_id, ..) in new_obligations {
+            info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
+
+            // build the json input for coprocessor client
+            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
+
+            // post the proof request to the coprocessor client & await
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            let vault_zkp_response = self
+                .coprocessor_client
+                .prove(
+                    &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
+                    &withdraw_id_json,
+                )
+                .await?;
+            info!(target: REGISTRATION_PHASE, "vault zkp resp: {vault_zkp_response:?}");
+
+            // extract the program and domain parameters by decoding the zkp
+            let (proof_program, inputs_program) = vault_zkp_response.program.decode()?;
+            let (proof_domain, inputs_domain) = vault_zkp_response.domain.decode()?;
+
+            // submits the decoded zkp parameters to the program authorizations module
+            valence_core::post_zkp_on_chain(
+                &self.neutron_client,
+                &self.cfg.neutron.authorizations,
+                (proof_program, inputs_program),
+                (proof_domain, inputs_domain),
+            )
+            .await?;
+
+            // tick the processor to register the obligation to the clearing queue
+            valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
+        }
+
+        info!(target: REGISTRATION_PHASE, "finished processing withdraw requests; concluding obligation registration phase...");
+
+        Ok(())
+    }
+}

--- a/strategies/maxbtc_mint/strategist/src/phases/sentry.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/sentry.rs
@@ -1,0 +1,20 @@
+use std::time::Duration;
+
+use log::info;
+use packages::phases::SENTRY_PHASE;
+use tokio::time::sleep;
+
+use crate::strategy_config::Strategy;
+
+impl Strategy {
+    /// basic sentry phase which sleeps for the duration configured
+    /// in the strategist config.
+    /// for more elaborate sentry configurations, see the strategist
+    /// getting started guide.
+    pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
+        sleep(Duration::from_secs(self.timeout)).await;
+
+        Ok(())
+    }
+}

--- a/strategies/maxbtc_mint/strategist/src/phases/settlement.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/settlement.rs
@@ -1,0 +1,78 @@
+use cosmwasm_std::to_json_binary;
+use log::info;
+use packages::{labels::SETTLE_OBLIGATION_LABEL, phases::SETTLEMENT_PHASE, utils::valence_core};
+use valence_clearing_queue_supervaults::{msg::ObligationsResponse, state::WithdrawalObligation};
+use valence_domain_clients::cosmos::{base_client::BaseClient, wasm_client::WasmClient};
+
+use crate::strategy_config::Strategy;
+
+impl Strategy {
+    pub async fn settlement(&mut self) -> anyhow::Result<()> {
+        info!(target: SETTLEMENT_PHASE, "starting settlement phase");
+
+        let settlement_bal_maxbtc = self
+            .neutron_client
+            .query_balance(
+                &self.cfg.neutron.accounts.settlement,
+                &self.cfg.neutron.denoms.maxbtc,
+            )
+            .await?;
+        info!(target: SETTLEMENT_PHASE, "settlement maxBTC balance = {settlement_bal_maxbtc}");
+
+        // query the Clearing Queue pending obligations
+        let ObligationsResponse { obligations } = self
+            .neutron_client
+            .query_contract_state(
+                &self.cfg.neutron.libraries.clearing_queue,
+                valence_clearing_queue_supervaults::msg::QueryMsg::PendingObligations {
+                    from: None,
+                    to: None,
+                },
+            )
+            .await?;
+
+        // early return if there is nothing to settle
+        if obligations.is_empty() {
+            info!(target: SETTLEMENT_PHASE, "no obligations to settle; concluding settlement phase");
+            return Ok(());
+        }
+
+        for o in &obligations {
+            info!(target: SETTLEMENT_PHASE, "obligation #{} payouts: {:?}", o.id, o.payout_coins);
+        }
+
+        // process the Clearing Queue settlement requests by enqueuing the settlement
+        // messages to the processor and ticking
+        self.clear_withdraw_obligations(obligations).await?;
+
+        Ok(())
+    }
+
+    async fn clear_withdraw_obligations(
+        &mut self,
+        obligations: Vec<WithdrawalObligation>,
+    ) -> anyhow::Result<()> {
+        let settlement_exec_msg = valence_library_utils::msg::ExecuteMsg::<_, ()>::ProcessFunction(
+            valence_clearing_queue_supervaults::msg::FunctionMsgs::SettleNextObligation {},
+        );
+
+        for obligation in obligations {
+            info!(
+                target: SETTLEMENT_PHASE, "settling obligation #{}", obligation.id
+            );
+
+            // enqueue the settlement message and tick the processor
+            valence_core::enqueue_neutron(
+                &self.neutron_client,
+                &self.cfg.neutron.authorizations,
+                SETTLE_OBLIGATION_LABEL,
+                vec![to_json_binary(&settlement_exec_msg)?],
+            )
+            .await?;
+
+            valence_core::tick_neutron(&self.neutron_client, &self.cfg.neutron.processor).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/strategies/maxbtc_mint/strategist/src/phases/update.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/update.rs
@@ -1,0 +1,245 @@
+use alloy::{primitives::U256, providers::Provider};
+use anyhow::anyhow;
+use cosmwasm_std::{Decimal, Uint128};
+use log::{info, warn};
+use packages::{
+    phases::UPDATE_PHASE,
+    types::sol_types::{BaseAccount, ERC20, OneWayVault},
+    utils::maxbtc::query_maxbtc_exchange_amount,
+};
+use std::cmp::Ordering;
+use valence_domain_clients::{
+    cosmos::base_client::BaseClient,
+    evm::base_client::{CustomProvider, EvmBaseClient},
+};
+
+use crate::strategy_config::Strategy;
+
+impl Strategy {
+    /// performs the vault rate update. this phase involves the following stages:
+    /// 1. calculating the total amount of deposit assets distributed across all
+    ///    active program domain accounts
+    /// 2. convert these assets to their equivalent value in maxBTC
+    /// 3. add this to the maxBTC in the settlement account
+    /// 4. querying the shares issued by the vault on Ethereum
+    /// 5. calculating the new redemption rate by dividing the total maxBTC
+    ///    amount by the total shares
+    /// 6. validating the new redemption rate
+    /// 7. posting the updated rate to the Ethereum vault
+    pub async fn update(&mut self, eth_rp: &CustomProvider) -> anyhow::Result<()> {
+        info!(target: UPDATE_PHASE, "starting vault update phase");
+
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
+
+        // in order to calculate the vault rate we need to find the total amount of deposit
+        // denom distributed across the program and convert it to the equivalent maxBTC value
+        let total_assets_in_maxbtc = self.total_assets_in_maxbtc(eth_rp).await?;
+        info!(target: UPDATE_PHASE, "total assets in maxBTC: {total_assets_in_maxbtc}");
+
+        // fetch the total issued shares and convert them to u128
+        let total_shares = self.total_issued_shares(eth_rp).await?;
+        info!(target: UPDATE_PHASE, "eth_vault_issued_shares_u128={total_shares}");
+
+        // rate = effective_total_assets_in_maxBTC / (effective_vault_shares * scaling_factor)
+        // multiplying the denominator by the scaling factor
+        let scaled_shares_amount =
+            Uint128::from(total_shares).checked_mul(self.cfg.ethereum.rate_scaling_factor)?;
+        let redemption_rate_decimal =
+            Decimal::checked_from_ratio(total_assets_in_maxbtc, scaled_shares_amount)?;
+        info!(target: UPDATE_PHASE, "redemption rate decimal={redemption_rate_decimal}");
+
+        let redemption_rate_sol_u256 = U256::try_from(redemption_rate_decimal.atomics().u128())?;
+        info!(target: UPDATE_PHASE, "redemption_rate_sol_u256={redemption_rate_sol_u256}");
+
+        // validate that the newly calculated redemption rate does not exceed
+        // the max rate update thresholds relative to the current rate
+        self.validate_new_redemption_rate(eth_rp, redemption_rate_sol_u256)
+            .await?;
+
+        info!(target: UPDATE_PHASE, "updating ethereum vault redemption rate");
+        let update_request = one_way_vault_contract
+            .update(redemption_rate_sol_u256)
+            .into_transaction_request();
+
+        let update_vault_exec_response = self.eth_client.sign_and_send(update_request).await?;
+
+        eth_rp
+            .get_transaction_receipt(update_vault_exec_response.transaction_hash)
+            .await?;
+
+        Ok(())
+    }
+
+    /// checks that the newly calculated redemption rate is within the acceptable
+    /// rate update bounds relative to the current rate. pauses the vault otherwise.
+    async fn validate_new_redemption_rate(
+        &self,
+        eth_rp: &CustomProvider,
+        new_redemption_rate: U256,
+    ) -> anyhow::Result<()> {
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
+
+        let current_vault_rate = self
+            .eth_client
+            .query(one_way_vault_contract.redemptionRate())
+            .await?
+            ._0;
+
+        let current_rate_u128 = u128::try_from(current_vault_rate)?;
+        info!(target: UPDATE_PHASE, "pre_update_rate = {current_rate_u128}");
+
+        // get the ratio of newly calculated redemption rate over the previous rate
+        let redemption_rate_u128 = u128::try_from(new_redemption_rate)?;
+        info!(target: UPDATE_PHASE, "new_rate = {redemption_rate_u128}");
+
+        let rate_change_decimal =
+            Decimal::checked_from_ratio(redemption_rate_u128, current_rate_u128)?;
+
+        info!(target: UPDATE_PHASE, "new to old rate ratio = {rate_change_decimal}");
+
+        match rate_change_decimal.cmp(&Decimal::one()) {
+            // rate change is less than 1.0 -> redemption rate decreased
+            Ordering::Less => {
+                let rate_delta = Decimal::one() - rate_change_decimal;
+                info!(target: UPDATE_PHASE, "redemption rate epoch delta = -{rate_delta}");
+                let decrement_threshold = Decimal::bps(self.cfg.ethereum.max_rate_decrement_bps);
+                if rate_delta > decrement_threshold {
+                    warn!(target: UPDATE_PHASE, "rate delta exceeds the threshold of {decrement_threshold}; pausing the vault");
+                    let pause_request = one_way_vault_contract.pause().into_transaction_request();
+                    let pause_vault_exec_response =
+                        self.eth_client.sign_and_send(pause_request).await?;
+                    eth_rp
+                        .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                        .await?;
+
+                    return Err(anyhow!(
+                        "newly calculated rate exceeds the rate update thresholds"
+                    ));
+                }
+            }
+            // rate change is exactly 1.0 -> redemption rate did not change
+            Ordering::Equal => {
+                info!(target: UPDATE_PHASE, "redemption rate epoch delta = 0.0");
+            }
+            // rate change is greater than 1.0 -> redemption rate increased
+            Ordering::Greater => {
+                let rate_delta = rate_change_decimal - Decimal::one();
+                info!(target: UPDATE_PHASE, "redemption rate epoch delta = +{rate_delta}");
+                let increment_threshold = Decimal::bps(self.cfg.ethereum.max_rate_increment_bps);
+                if rate_delta > increment_threshold {
+                    warn!(target: UPDATE_PHASE, "rate delta exceeds the threshold of {increment_threshold}; pausing the vault");
+                    let pause_request = one_way_vault_contract.pause().into_transaction_request();
+                    let pause_vault_exec_response =
+                        self.eth_client.sign_and_send(pause_request).await?;
+                    eth_rp
+                        .get_transaction_receipt(pause_vault_exec_response.transaction_hash)
+                        .await?;
+
+                    return Err(anyhow!(
+                        "newly calculated rate exceeds the rate update thresholds"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn total_issued_shares(&self, eth_rp: &CustomProvider) -> anyhow::Result<u128> {
+        let one_way_vault_contract =
+            OneWayVault::new(self.cfg.ethereum.libraries.one_way_vault, &eth_rp);
+
+        let eth_vault_issued_shares_u256 = self
+            .eth_client
+            .query(one_way_vault_contract.totalSupply())
+            .await?
+            ._0;
+
+        // if there are no shares issued, update cannot be performed because it's impossible to
+        // calculate the redemption rate
+        if eth_vault_issued_shares_u256.is_zero() {
+            return Err(anyhow!(
+                "cannot calculate redemption rate with zero issued vault shares"
+            ));
+        }
+
+        info!(target: UPDATE_PHASE, "eth_vault_issued_shares_u256={eth_vault_issued_shares_u256}");
+
+        // perform u256 -> u128 conversion
+        let eth_vault_issued_shares_u128 = u128::try_from(eth_vault_issued_shares_u256)?;
+
+        Ok(eth_vault_issued_shares_u128)
+    }
+
+    /// queries the total value of the vault, expressed in maxBTC
+    /// this involves querying the deposit token balances as well as the maxBTC balance
+    /// in the settlement account, and convert everything to maxBTC
+    /// - deposit denom balance queries:
+    ///   - ethereum deposit account
+    ///   - cosmos hub ICA
+    ///   - neutron deposit account
+    /// - maxBTC balance queries:
+    ///   - neutron settlement account
+    async fn total_assets_in_maxbtc(&self, eth_rp: &CustomProvider) -> anyhow::Result<u128> {
+        let eth_deposit_acc_contract =
+            BaseAccount::new(self.cfg.ethereum.accounts.deposit, &eth_rp);
+        let eth_deposit_denom_contract =
+            ERC20::new(self.cfg.ethereum.denoms.deposit_token, &eth_rp);
+
+        let mut deposit_token_balance_total: u128 = 0;
+
+        let eth_deposit_acc_balance_u256 = self
+            .eth_client
+            .query(eth_deposit_denom_contract.balanceOf(*eth_deposit_acc_contract.address()))
+            .await?
+            ._0;
+        info!(target: UPDATE_PHASE, "eth_deposit_acc_balance_u256={eth_deposit_acc_balance_u256}");
+
+        // perform u256 -> u128 conversion
+        let eth_deposit_token_total_u128 = u128::try_from(eth_deposit_acc_balance_u256)?;
+        info!(target: UPDATE_PHASE, "eth_deposit_token_total_u128={eth_deposit_token_total_u128}");
+        deposit_token_balance_total += eth_deposit_token_total_u128;
+
+        let gaia_ica_balance = self
+            .gaia_client
+            .query_balance(&self.cfg.gaia.ica_address, &self.cfg.gaia.deposit_denom)
+            .await?;
+        info!(target: UPDATE_PHASE, "gaia_ica_balance={gaia_ica_balance}");
+        deposit_token_balance_total += gaia_ica_balance;
+
+        let neutron_deposit_acc_balance = self
+            .neutron_client
+            .query_balance(
+                &self.cfg.neutron.accounts.deposit,
+                &self.cfg.neutron.denoms.deposit_token,
+            )
+            .await?;
+        info!(target: UPDATE_PHASE, "neutron_deposit_acc_balance={neutron_deposit_acc_balance}");
+        deposit_token_balance_total += neutron_deposit_acc_balance;
+
+        let neutron_settlement_acc_maxbtc_balance = self
+            .neutron_client
+            .query_balance(
+                &self.cfg.neutron.accounts.settlement,
+                &self.cfg.neutron.denoms.maxbtc,
+            )
+            .await?;
+        info!(target: UPDATE_PHASE, "neutron_settlement_acc_maxbtc_balance={neutron_settlement_acc_maxbtc_balance}");
+
+        let deposit_token_balance_in_maxbtc = query_maxbtc_exchange_amount(
+            &self.neutron_client,
+            &self.cfg.neutron.maxbtc_contract,
+            deposit_token_balance_total,
+        )
+        .await?;
+        info!(target: UPDATE_PHASE, "deposit_token_balance_in_maxbtc={deposit_token_balance_in_maxbtc}");
+
+        let total_maxbtc_balance =
+            deposit_token_balance_in_maxbtc + neutron_settlement_acc_maxbtc_balance;
+        info!(target: UPDATE_PHASE, "total_maxbtc_balance={total_maxbtc_balance}");
+
+        Ok(total_maxbtc_balance)
+    }
+}

--- a/strategies/maxbtc_mint/strategist/src/strategist.rs
+++ b/strategies/maxbtc_mint/strategist/src/strategist.rs
@@ -1,0 +1,47 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+use log::info;
+use packages::phases::VALENCE_WORKER;
+use valence_domain_clients::evm::{
+    base_client::CustomProvider, request_provider_client::RequestProviderClient,
+};
+use valence_strategist_utils::worker::ValenceWorker;
+
+use crate::strategy_config::Strategy;
+
+// implement the ValenceWorker trait for the Strategy struct.
+// This trait defines the main loop of the strategy and inherits
+// the default implementation for spawning the worker.
+#[async_trait]
+impl ValenceWorker for Strategy {
+    fn get_name(&self) -> String {
+        format!("Valence X-Vault: {}", self.label)
+    }
+
+    async fn cycle(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        info!(target: VALENCE_WORKER, "{}: Starting cycle...", self.get_name());
+
+        // go into sentry (pre-flight) phase
+        self.sentry().await?;
+
+        let eth_rp: CustomProvider = self.eth_client.get_request_provider().await?;
+
+        // first we carry out the deposit flow
+        self.deposit(&eth_rp).await?;
+
+        // after deposit flow is complete, we process the new obligations
+        self.register_withdraw_obligations().await?;
+
+        // with new obligations registered into the clearing queue, we
+        // carry out the settlements
+        self.settlement().await?;
+
+        // having processed all new exit requests after the deposit flow,
+        // the epoch is ready to be concluded.
+        // we perform the final accounting flow and post vault update.
+        self.update(&eth_rp).await?;
+
+        Ok(())
+    }
+}

--- a/strategies/maxbtc_mint/strategist/src/strategy_config.rs
+++ b/strategies/maxbtc_mint/strategist/src/strategy_config.rs
@@ -1,0 +1,146 @@
+use std::{env, path::Path};
+
+use anyhow::anyhow;
+use maxbtc_mint_types::{
+    ethereum_config::EthereumStrategyConfig, gaia_config::GaiaStrategyConfig,
+    neutron_config::NeutronStrategyConfig,
+};
+use packages::ibc_eureka_chain_ids::{EUREKA_COSMOS_HUB_CHAIN_ID, EUREKA_ETHEREUM_CHAIN_ID};
+use valence_domain_clients::clients::{
+    coprocessor::CoprocessorClient, ethereum::EthereumClient, gaia::CosmosHubClient,
+    ibc_eureka_route_client::IBCEurekaRouteClient, neutron::NeutronClient,
+    valence_indexer::OneWayVaultIndexerClient,
+};
+
+use serde::{Deserialize, Serialize};
+use valence_strategist_utils::worker::ValenceWorkerTomlSerde;
+
+/// top-level config that wraps around each domain configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StrategyConfig {
+    pub ethereum: EthereumStrategyConfig,
+    pub neutron: NeutronStrategyConfig,
+    pub gaia: GaiaStrategyConfig,
+}
+
+// main strategy struct that wraps around the StrategyConfig
+// and stores the initialized clients
+pub struct Strategy {
+    /// strategy name
+    pub label: String,
+
+    /// strategy timeout (in seconds)
+    pub timeout: u64,
+
+    /// top level strategy configuration
+    pub cfg: StrategyConfig,
+
+    /// active ethereum client
+    pub(crate) eth_client: EthereumClient,
+    /// active cosmos hub client
+    pub(crate) gaia_client: CosmosHubClient,
+    /// active neutron client
+    pub(crate) neutron_client: NeutronClient,
+    /// active one way vault indexer client
+    pub(crate) indexer_client: OneWayVaultIndexerClient,
+    /// skip route client for IBC eureka
+    pub(crate) ibc_eureka_client: IBCEurekaRouteClient,
+    /// active coprocessor client
+    pub(crate) coprocessor_client: CoprocessorClient,
+}
+
+#[allow(dead_code)]
+impl Strategy {
+    /// strategy initializer that takes in a `StrategyConfig`, and uses it
+    /// to initialize the respective domain clients. prerequisite to starting
+    /// the strategist.
+    pub async fn new(cfg: StrategyConfig) -> anyhow::Result<Self> {
+        let mnemonic =
+            env::var("MNEMONIC").map_err(|e| anyhow!("mnemonic must be provided: {e}"))?;
+        let label = env::var("LABEL").map_err(|e| anyhow!("label must be provided: {e}"))?;
+        let indexer_api_key = env::var("INDEXER_API_KEY")
+            .map_err(|e| anyhow!("indexer api key must be provided: {e}"))?;
+        let indexer_api_url = env::var("INDEXER_API_URL")
+            .map_err(|e| anyhow!("indexer api url key must be provided: {e}"))?;
+        let eureka_api_url = env::var("EUREKA_API_URL")
+            .map_err(|e| anyhow!("IBC Eureka route api url must be provided: {e}"))?;
+        let strategy_timeout: u64 = env::var("STRATEGY_TIMEOUT")
+            .map_err(|e| anyhow!("Strategy timeout must be provided: {e}"))?
+            .parse()?;
+
+        let gaia_client = CosmosHubClient::new(
+            &cfg.gaia.grpc_url,
+            &cfg.gaia.grpc_port,
+            &mnemonic,
+            &cfg.gaia.chain_id,
+            &cfg.gaia.chain_denom,
+        )
+        .await?;
+
+        let neutron_client = NeutronClient::new(
+            &cfg.neutron.grpc_url,
+            &cfg.neutron.grpc_port,
+            &mnemonic,
+            &cfg.neutron.chain_id,
+        )
+        .await?;
+
+        let eth_client = EthereumClient::new(&cfg.ethereum.rpc_url, &mnemonic, None)?;
+
+        let indexer_client = OneWayVaultIndexerClient::new(
+            &indexer_api_url,
+            &indexer_api_key,
+            &cfg.ethereum.libraries.one_way_vault.to_string(),
+        );
+
+        let coprocessor_client = CoprocessorClient::default();
+
+        let ibc_eureka_client = IBCEurekaRouteClient::new(
+            &eureka_api_url,
+            EUREKA_ETHEREUM_CHAIN_ID,
+            &cfg.ethereum.denoms.deposit_token.to_string(),
+            EUREKA_COSMOS_HUB_CHAIN_ID,
+            &cfg.gaia.deposit_denom,
+        );
+
+        Ok(Self {
+            cfg,
+            timeout: strategy_timeout,
+            eth_client,
+            gaia_client,
+            neutron_client,
+            label,
+            indexer_client,
+            coprocessor_client,
+            ibc_eureka_client,
+        })
+    }
+
+    /// constructor helper that takes in four paths:
+    /// - neutron config path
+    /// - ethereum config path
+    /// - cosmos hub config path
+    ///
+    /// reads the configs from those paths, sets up each domain config,
+    /// wraps them in a `StrategyConfig`, and uses that to call the initializer above.
+    pub async fn from_files<P: AsRef<Path>>(
+        neutron_path: P,
+        gaia_path: P,
+        eth_path: P,
+    ) -> anyhow::Result<Self> {
+        let neutron_cfg = NeutronStrategyConfig::from_file(neutron_path)
+            .map_err(|e| anyhow!("invalid neutron config: {:?}", e))?;
+        let eth_cfg = EthereumStrategyConfig::from_file(eth_path)
+            .map_err(|e| anyhow!("invalid ethereum config: {:?}", e))?;
+        let gaia_cfg = GaiaStrategyConfig::from_file(gaia_path)
+            .map_err(|e| anyhow!("invalid gaia config: {:?}", e))?;
+
+        let strategy_cfg = StrategyConfig {
+            ethereum: eth_cfg,
+            neutron: neutron_cfg,
+            gaia: gaia_cfg,
+        };
+
+        Self::new(strategy_cfg).await
+    }
+}


### PR DESCRIPTION
Things to consider:

- This vault is slightly different than the rest in the sense that the redemption rate doesn't start 1:1 with the deposit token but instead it's the redemption rate with maxBTC.
Example: If at vault launch the rate is 0.5 maxBTC per 1 WBTC, we'll launch the vault with `50000000`  instead of `100000000`.

- We can reuse the clearing queue library even though we are not using mars or supervaults. I do this by instantiating the clearing queue using the maxBTC denom which is what is sitting in the settlement account and make it 100%. This way we'll just receive the right amount from the ZK proof.

- Because of the points above the redemption rate update is slightly different as now we need to convert all the deposit token assets into maxBTC value to calculate the redemption rate.

- The query is not implemented yet so I left it as a TODO. Should be available by end of this week. 

This is the first strategist that I write so lmk if I messed something up.
