### PR TITLE
chore: bump coprocessor versions and instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
  "serde_json",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
  "valence-library-utils",
 ]
 
@@ -1923,7 +1923,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
  "valence-coprocessor-wasm",
 ]
 
@@ -1942,7 +1942,7 @@ dependencies = [
  "rlp 0.6.1",
  "serde",
  "serde_json",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
  "valence-coprocessor-wasm",
 ]
 
@@ -2933,7 +2933,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-sol-types 0.8.25",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
 ]
 
 [[package]]
@@ -2943,7 +2943,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "serde_json",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
  "valence-coprocessor-wasm",
 ]
 
@@ -4663,7 +4663,7 @@ dependencies = [
  "alloy-sol-types 0.8.25",
  "anyhow",
  "serde_json",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
 ]
 
 [[package]]
@@ -4673,7 +4673,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "serde_json",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
  "valence-coprocessor-wasm",
 ]
 
@@ -9135,8 +9135,8 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor"
-version = "0.3.7"
-source = "git+https://github.com/timewave-computer/valence-coprocessor.git?tag=v0.3.7#5e169394898e805d6d7cac3a548c93ae7d6a0356"
+version = "0.3.12"
+source = "git+https://github.com/timewave-computer/valence-coprocessor.git?tag=v0.3.12#5cb5b00e2494bfb54ac6ed49badcb54acbc6572e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9181,15 +9181,15 @@ dependencies = [
 
 [[package]]
 name = "valence-coprocessor-wasm"
-version = "0.3.7"
-source = "git+https://github.com/timewave-computer/valence-coprocessor.git?tag=v0.3.7#5e169394898e805d6d7cac3a548c93ae7d6a0356"
+version = "0.3.12"
+source = "git+https://github.com/timewave-computer/valence-coprocessor.git?tag=v0.3.12#5cb5b00e2494bfb54ac6ed49badcb54acbc6572e"
 dependencies = [
  "anyhow",
  "lru 0.14.0",
  "msgpacker",
  "serde_json",
  "tracing",
- "valence-coprocessor 0.3.7",
+ "valence-coprocessor 0.3.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,5 +72,5 @@ valence-maxbtc-issuer                = { git = "https://github.com/timewave-comp
 valence-lending-utils                = { git = "https://github.com/timewave-computer/valence-protocol", rev = "062a77e" }
 
 # valence-coprocessor
-valence-coprocessor      = { git = "https://github.com/timewave-computer/valence-coprocessor.git", tag = "v0.3.7", default-features = false }
-valence-coprocessor-wasm = { git = "https://github.com/timewave-computer/valence-coprocessor.git", tag = "v0.3.7", default-features = false }
+valence-coprocessor      = { git = "https://github.com/timewave-computer/valence-coprocessor.git", tag = "v0.3.12", default-features = false }
+valence-coprocessor-wasm = { git = "https://github.com/timewave-computer/valence-coprocessor.git", tag = "v0.3.12", default-features = false }

--- a/coprocessor-apps/README.md
+++ b/coprocessor-apps/README.md
@@ -40,7 +40,7 @@ just compile clearing-queue
 or alternatively
 
 ```bash
-cargo-valence --socket https://service.coprocessor.valence.zone \
+    cargo-valence --socket https://service.coprocessor.valence.zone \
     deploy circuit \
     --controller ./coprocessor-apps/<app_name>/controller \
     --circuit <app_name>-circuit

--- a/coprocessor-apps/README.md
+++ b/coprocessor-apps/README.md
@@ -40,7 +40,7 @@ just compile clearing-queue
 or alternatively
 
 ```bash
-    cargo-valence --socket https://service.coprocessor.valence.zone/ \
+cargo-valence --socket https://service.coprocessor.valence.zone \
     deploy circuit \
     --controller ./coprocessor-apps/<app_name>/controller \
     --circuit <app_name>-circuit

--- a/coprocessor-apps/README.md
+++ b/coprocessor-apps/README.md
@@ -19,7 +19,7 @@ To install:
 ```bash
 cargo install \
   --git https://github.com/timewave-computer/valence-coprocessor.git \
-  --tag v0.3.7 \
+  --tag v0.3.12 \
   --locked cargo-valence
 ```
 
@@ -40,7 +40,7 @@ just compile clearing-queue
 or alternatively
 
 ```bash
-    cargo-valence --socket prover.timewave.computer:37281 \
+    cargo-valence --socket https://service.coprocessor.valence.zone/ \
     deploy circuit \
     --controller ./coprocessor-apps/<app_name>/controller \
     --circuit <app_name>-circuit

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ start strategy:
     RUST_LOG=info cargo run -p {{strategy}}_strategist --bin runner
     
 compile circuit:
-    cargo-valence --socket prover.timewave.computer:37281 \
+    cargo-valence --socket https://service.coprocessor.valence.zone/ \
     deploy circuit \
     --controller ./coprocessor-apps/{{circuit}}/controller \
     --circuit {{circuit}}-circuit

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ start strategy:
     RUST_LOG=info cargo run -p {{strategy}}_strategist --bin runner
     
 compile circuit:
-    cargo-valence --socket https://service.coprocessor.valence.zone/ \
+    cargo-valence --socket https://service.coprocessor.valence.zone \
     deploy circuit \
     --controller ./coprocessor-apps/{{circuit}}/controller \
     --circuit {{circuit}}-circuit


### PR DESCRIPTION
update coprocessor versions to 0.3.12 and the prover URL used for the deployment