### PR TITLE
fix: mars accounting query helper

### DIFF
--- a/strategies/cctp_lend/deploy/src/artifacts/neutron_strategy_config.toml
+++ b/strategies/cctp_lend/deploy/src/artifacts/neutron_strategy_config.toml
@@ -1,5 +1,5 @@
-grpc_url = "http://rpc.neutron.quokkastake.io"
-grpc_port = "9090"
+grpc_url = "http://neutron-grpc.polkachu.com"
+grpc_port = "19190"
 chain_id = "neutron-1"
 mars_credit_manager = "neutron1qdzn3l4kn7gsjna2tfpg3g3mwd6kunx4p50lfya59k02846xas6qslgs3r"
 authorizations = "neutron1x63lhjd9et48ct6hygd2l03u27c4j409d0cw8tzxmau3yw0u8f6ql4usk6"


### PR DESCRIPTION
# Description

## Why

When performing the mars position accounting query, configured grpc node returned a query out of gas error. This resulted in incorrect mars accounting, as in case of an error the helper method defaulted to 0.

## Changes

Surface the error in case of a failed query request instead of returning 0.