### PR TITLE
feat: add the maxbtc simulate deposit query

### DIFF
--- a/packages/src/utils/maxbtc.rs
+++ b/packages/src/utils/maxbtc.rs
@@ -1,11 +1,30 @@
-use valence_domain_clients::clients::neutron::NeutronClient;
+use cosmwasm_std::Uint128;
+use valence_domain_clients::{clients::neutron::NeutronClient, cosmos::wasm_client::WasmClient};
 
-pub async fn query_maxbtc_exchange_amount(
-    _client: &NeutronClient,
-    _maxbtc_contract: &str,
-    _amount: u128,
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+enum QueryMsg {
+    SimulateDeposit { amount: Uint128 },
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+struct SimulateDepositResponse {
+    minted_amount: Uint128,
+}
+
+pub async fn query_maxbtc_simulate_deposit(
+    client: &NeutronClient,
+    maxbtc_contract: &str,
+    amount: u128,
 ) -> anyhow::Result<u128> {
-    // TODO: Implement the logic to query how much maxBTC we would get for depositing a certain amount into the maxBTC contract
-    // This query is not available yet but will be soon
-    Ok(0)
+    let simulate_deposit = QueryMsg::SimulateDeposit {
+        amount: Uint128::new(amount),
+    };
+
+    let response: SimulateDepositResponse = client
+        .query_contract_state(maxbtc_contract, simulate_deposit)
+        .await?;
+
+    Ok(response.minted_amount.u128())
 }

--- a/strategies/maxbtc_mint/deploy/src/inputs/neutron.toml
+++ b/strategies/maxbtc_mint/deploy/src/inputs/neutron.toml
@@ -14,8 +14,8 @@ ica_timeout                = 43200                                              
 
 [program]
 deposit_token_on_neutron_denom = "ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E" # Should be token denom on Neutron
-maxbtc_contract = "neutron1qh7fj57et5ac645k272pa6w089tlhj678a3dtr7k0lp523p37q2sase0td" # The contract address where maxBTC are minted from
-maxbtc_denom = "factory/neutron1qh7fj57et5ac645k272pa6w089tlhj678a3dtr7k0lp523p37q2sase0td/maxbtc" # Should be real maxBTC denom on Neutron
+maxbtc_contract = "neutron1hq65gh2rfh6d08hpk7u48u0fjly6qezdwp95t7dydvxxnv7r9zhstpct4v" # The contract address where maxBTC are minted from
+maxbtc_denom = "factory/neutron1hq65gh2rfh6d08hpk7u48u0fjly6qezdwp95t7dydvxxnv7r9zhstpct4v/maxbtc" # Should be real maxBTC denom on Neutron
 
 [coprocessor_app]
 clearing_queue_coprocessor_app_id = "" # TBD after deployment

--- a/strategies/maxbtc_mint/strategist/src/phases/update.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/update.rs
@@ -5,7 +5,7 @@ use log::info;
 use packages::{
     phases::UPDATE_PHASE,
     types::sol_types::{BaseAccount, ERC20, OneWayVault},
-    utils::{maxbtc::query_maxbtc_exchange_amount, valence_core},
+    utils::{maxbtc::query_maxbtc_simulate_deposit, valence_core},
 };
 use valence_domain_clients::{
     cosmos::base_client::BaseClient,
@@ -158,7 +158,7 @@ impl Strategy {
             .await?;
         info!(target: UPDATE_PHASE, "neutron_settlement_acc_maxbtc_balance={neutron_settlement_acc_maxbtc_balance}");
 
-        let deposit_token_balance_in_maxbtc = query_maxbtc_exchange_amount(
+        let deposit_token_balance_in_maxbtc = query_maxbtc_simulate_deposit(
             &self.neutron_client,
             &self.cfg.neutron.maxbtc_contract,
             deposit_token_balance_total,


### PR DESCRIPTION
I don't think the repo is public so need to define the API myself, tested it and it works.
If they open source it we can take their maxbtc contract repo as a dependency and reuse from there