### PR TITLE
Fix: ica_transfer_label constant in wbtc deposit phase

### DIFF
--- a/strategies/wbtc/strategist/src/phases/deposit.rs
+++ b/strategies/wbtc/strategist/src/phases/deposit.rs
@@ -5,7 +5,6 @@ use alloy::{
 use cosmwasm_std::to_json_binary;
 use log::{info, warn};
 use packages::{
-    labels::ICA_TRANSFER_LABEL,
     phases::DEPOSIT_PHASE,
     types::sol_types::{Authorization, BaseAccount, ERC20},
     utils::{self, valence_core},
@@ -17,7 +16,7 @@ use valence_domain_clients::{
     evm::base_client::{CustomProvider, EvmBaseClient},
 };
 use valence_library_utils::OptionUpdate;
-use wbtc_types::labels::LEND_AND_PROVIDE_LIQUIDITY_PHASE1_LABEL;
+use wbtc_types::labels::{ICA_TRANSFER_LABEL, LEND_AND_PROVIDE_LIQUIDITY_PHASE1_LABEL};
 
 use crate::strategy_config::Strategy;
 


### PR DESCRIPTION
Initialization and deposit phases in wbtc strategy use `ICA_TRANSFER_LABEL` constants from different packages where they have different values (`ica_transfer2` and `ica_transfer`). This PR fixes the issue by using the same constant in every phase