### PR TITLE
feat: flush neutron processor queue at the start of cycle

### DIFF
--- a/strategies/btc_lst/strategist/src/phases/sentry.rs
+++ b/strategies/btc_lst/strategist/src/phases/sentry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::info;
-use packages::phases::SENTRY_PHASE;
+use packages::{phases::SENTRY_PHASE, utils::valence_core};
 use tokio::time::sleep;
 
 use crate::strategy_config::Strategy;
@@ -12,6 +12,21 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        // before starting the cycle we flush any existing medium or high
+        // priority items from the processor queue
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::Medium,
+        )
+        .await?;
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::High,
+        )
+        .await?;
+
         info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
         sleep(Duration::from_secs(self.timeout)).await;
 

--- a/strategies/btc_lst/strategist/src/phases/sentry.rs
+++ b/strategies/btc_lst/strategist/src/phases/sentry.rs
@@ -12,18 +12,12 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
-        // before starting the cycle we flush any existing medium or high
-        // priority items from the processor queue
+        // before starting the cycle we flush any existing items
+        // from the processor queue
         valence_core::flush_neutron_processor_queue(
             &self.neutron_client,
             &self.cfg.neutron.processor,
             valence_authorization_utils::authorization::Priority::Medium,
-        )
-        .await?;
-        valence_core::flush_neutron_processor_queue(
-            &self.neutron_client,
-            &self.cfg.neutron.processor,
-            valence_authorization_utils::authorization::Priority::High,
         )
         .await?;
 

--- a/strategies/cctp_lend/strategist/src/phases/sentry.rs
+++ b/strategies/cctp_lend/strategist/src/phases/sentry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::info;
-use packages::phases::SENTRY_PHASE;
+use packages::{phases::SENTRY_PHASE, utils::valence_core};
 use tokio::time::sleep;
 
 use crate::strategy_config::Strategy;
@@ -12,6 +12,21 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        // before starting the cycle we flush any existing medium or high
+        // priority items from the processor queue
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::Medium,
+        )
+        .await?;
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::High,
+        )
+        .await?;
+
         info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
         sleep(Duration::from_secs(self.timeout)).await;
 

--- a/strategies/cctp_lend/strategist/src/phases/sentry.rs
+++ b/strategies/cctp_lend/strategist/src/phases/sentry.rs
@@ -12,18 +12,12 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
-        // before starting the cycle we flush any existing medium or high
-        // priority items from the processor queue
+        // before starting the cycle we flush any existing items
+        // from the processor queue
         valence_core::flush_neutron_processor_queue(
             &self.neutron_client,
             &self.cfg.neutron.processor,
             valence_authorization_utils::authorization::Priority::Medium,
-        )
-        .await?;
-        valence_core::flush_neutron_processor_queue(
-            &self.neutron_client,
-            &self.cfg.neutron.processor,
-            valence_authorization_utils::authorization::Priority::High,
         )
         .await?;
 

--- a/strategies/lombard_btc/strategist/src/phases/sentry.rs
+++ b/strategies/lombard_btc/strategist/src/phases/sentry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::info;
-use packages::phases::SENTRY_PHASE;
+use packages::{phases::SENTRY_PHASE, utils::valence_core};
 use tokio::time::sleep;
 
 use crate::strategy_config::Strategy;
@@ -12,6 +12,21 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        // before starting the cycle we flush any existing medium or high
+        // priority items from the processor queue
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::Medium,
+        )
+        .await?;
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::High,
+        )
+        .await?;
+
         info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
         sleep(Duration::from_secs(self.timeout)).await;
 

--- a/strategies/lombard_btc/strategist/src/phases/sentry.rs
+++ b/strategies/lombard_btc/strategist/src/phases/sentry.rs
@@ -12,18 +12,12 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
-        // before starting the cycle we flush any existing medium or high
-        // priority items from the processor queue
+        // before starting the cycle we flush any existing items
+        // from the processor queue
         valence_core::flush_neutron_processor_queue(
             &self.neutron_client,
             &self.cfg.neutron.processor,
             valence_authorization_utils::authorization::Priority::Medium,
-        )
-        .await?;
-        valence_core::flush_neutron_processor_queue(
-            &self.neutron_client,
-            &self.cfg.neutron.processor,
-            valence_authorization_utils::authorization::Priority::High,
         )
         .await?;
 

--- a/strategies/maxbtc_mint/strategist/src/phases/sentry.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/sentry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::info;
-use packages::phases::SENTRY_PHASE;
+use packages::{phases::SENTRY_PHASE, utils::valence_core};
 use tokio::time::sleep;
 
 use crate::strategy_config::Strategy;
@@ -12,6 +12,21 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        // before starting the cycle we flush any existing medium or high
+        // priority items from the processor queue
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::Medium,
+        )
+        .await?;
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::High,
+        )
+        .await?;
+
         info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
         sleep(Duration::from_secs(self.timeout)).await;
 

--- a/strategies/maxbtc_mint/strategist/src/phases/sentry.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/sentry.rs
@@ -12,18 +12,12 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
-        // before starting the cycle we flush any existing medium or high
-        // priority items from the processor queue
+        // before starting the cycle we flush any existing items
+        // from the processor queue
         valence_core::flush_neutron_processor_queue(
             &self.neutron_client,
             &self.cfg.neutron.processor,
             valence_authorization_utils::authorization::Priority::Medium,
-        )
-        .await?;
-        valence_core::flush_neutron_processor_queue(
-            &self.neutron_client,
-            &self.cfg.neutron.processor,
-            valence_authorization_utils::authorization::Priority::High,
         )
         .await?;
 

--- a/strategies/usdc/strategist/src/phases/sentry.rs
+++ b/strategies/usdc/strategist/src/phases/sentry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::info;
-use packages::phases::SENTRY_PHASE;
+use packages::{phases::SENTRY_PHASE, utils::valence_core};
 use tokio::time::sleep;
 
 use crate::strategy_config::Strategy;
@@ -12,6 +12,21 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        // before starting the cycle we flush any existing medium or high
+        // priority items from the processor queue
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::Medium,
+        )
+        .await?;
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::High,
+        )
+        .await?;
+
         info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
         sleep(Duration::from_secs(self.timeout)).await;
 

--- a/strategies/usdc/strategist/src/phases/sentry.rs
+++ b/strategies/usdc/strategist/src/phases/sentry.rs
@@ -12,18 +12,12 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
-        // before starting the cycle we flush any existing medium or high
-        // priority items from the processor queue
+        // before starting the cycle we flush any existing items
+        // from the processor queue
         valence_core::flush_neutron_processor_queue(
             &self.neutron_client,
             &self.cfg.neutron.processor,
             valence_authorization_utils::authorization::Priority::Medium,
-        )
-        .await?;
-        valence_core::flush_neutron_processor_queue(
-            &self.neutron_client,
-            &self.cfg.neutron.processor,
-            valence_authorization_utils::authorization::Priority::High,
         )
         .await?;
 

--- a/strategies/wbtc/strategist/src/phases/sentry.rs
+++ b/strategies/wbtc/strategist/src/phases/sentry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::info;
-use packages::phases::SENTRY_PHASE;
+use packages::{phases::SENTRY_PHASE, utils::valence_core};
 use tokio::time::sleep;
 
 use crate::strategy_config::Strategy;
@@ -12,6 +12,21 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
+        // before starting the cycle we flush any existing medium or high
+        // priority items from the processor queue
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::Medium,
+        )
+        .await?;
+        valence_core::flush_neutron_processor_queue(
+            &self.neutron_client,
+            &self.cfg.neutron.processor,
+            valence_authorization_utils::authorization::Priority::High,
+        )
+        .await?;
+
         info!(target: SENTRY_PHASE, "sleeping for {}sec", self.timeout);
         sleep(Duration::from_secs(self.timeout)).await;
 

--- a/strategies/wbtc/strategist/src/phases/sentry.rs
+++ b/strategies/wbtc/strategist/src/phases/sentry.rs
@@ -12,18 +12,12 @@ impl Strategy {
     /// for more elaborate sentry configurations, see the strategist
     /// getting started guide.
     pub async fn sentry(&mut self) -> anyhow::Result<()> {
-        // before starting the cycle we flush any existing medium or high
-        // priority items from the processor queue
+        // before starting the cycle we flush any existing items
+        // from the processor queue
         valence_core::flush_neutron_processor_queue(
             &self.neutron_client,
             &self.cfg.neutron.processor,
             valence_authorization_utils::authorization::Priority::Medium,
-        )
-        .await?;
-        valence_core::flush_neutron_processor_queue(
-            &self.neutron_client,
-            &self.cfg.neutron.processor,
-            valence_authorization_utils::authorization::Priority::High,
         )
         .await?;
 


### PR DESCRIPTION
# Description

Adds queue flushing calls to the sentry phases of each strategy