### PR TITLE
feat: domain clients update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.12",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -322,28 +322,6 @@ dependencies = [
  "thiserror 2.0.14",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.20",
- "hex-literal",
- "itoa",
- "k256",
- "keccak-asm",
- "proptest",
- "rand 0.8.5",
- "ruint",
- "serde",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -645,20 +623,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
-dependencies = [
- "alloy-sol-macro-expander 0.7.7",
- "alloy-sol-macro-input 0.7.7",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "alloy-sol-macro"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
@@ -683,24 +647,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
-dependencies = [
- "alloy-sol-macro-input 0.7.7",
- "const-hex",
- "heck 0.5.0",
- "indexmap 2.10.0",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "syn-solidity 0.7.7",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -738,21 +684,6 @@ dependencies = [
  "syn 2.0.104",
  "syn-solidity 1.3.0",
  "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
-dependencies = [
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "syn-solidity 0.7.7",
 ]
 
 [[package]]
@@ -796,19 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.12",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
-dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-macro 0.7.7",
- "const-hex",
- "serde",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -2020,7 +1939,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "valence-account-utils",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
@@ -2197,7 +2116,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.104",
  "tempfile",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -2228,7 +2147,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "valence-account-utils",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
@@ -2492,6 +2411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,12 +2476,6 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -3078,10 +3000,8 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
  "syn 2.0.104",
 ]
 
@@ -3944,12 +3864,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -5212,7 +5126,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "valence-account-utils",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
@@ -5338,7 +5252,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "valence-account-utils",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
@@ -6286,7 +6200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
  "valence-domain-clients",
@@ -6615,30 +6529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -7445,6 +7335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7746,6 +7642,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f777f77aeef456e47e75c2a4b16804b15395be5b344e2094a54965143ef1c31"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7771,6 +7678,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -8564,18 +8480,6 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "syn-solidity"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
@@ -8740,7 +8644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint",
- "toml",
+ "toml 0.8.23",
  "url",
 ]
 
@@ -9101,9 +9005,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -9116,13 +9035,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.10.0",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -9134,10 +9062,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.12",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -9145,6 +9082,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tonic"
@@ -9506,7 +9449,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "usdc_types",
  "valence-account-utils",
  "valence-authorization-utils",
@@ -9727,21 +9670,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "valence-crypto-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee185d7fece26df9b885480ca45e23016d20583288817017c3cb764adb2c599b"
+dependencies = [
+ "anyhow",
+ "const-hex",
+ "k256",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "valence-domain-clients"
-version = "1.1.0"
-source = "git+https://github.com/timewave-computer/valence-domain-clients.git?rev=885feb6#885feb6cff129e0eef9a69801c8b323aa8580ae0"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b001ceb382c8cd1ea77b72e49691e7b6b09307146b85943a22693214470e44"
 dependencies = [
  "alloy",
- "alloy-primitives 0.7.7",
  "alloy-signer-local",
- "alloy-sol-types 0.7.7",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bip32",
- "bs58",
+ "clap",
+ "colored",
+ "const-hex",
  "cosmos-sdk-proto 0.26.1",
  "cosmrs",
+ "ed25519-zebra",
  "hex",
  "ibc",
  "log",
@@ -9751,10 +9711,11 @@ dependencies = [
  "reqwest 0.12.23",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
  "tokio",
+ "toml 0.9.5",
  "tonic 0.12.3",
  "uuid 1.18.0",
+ "valence-crypto-utils",
 ]
 
 [[package]]
@@ -9977,7 +9938,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -10199,7 +10160,7 @@ dependencies = [
  "serde",
  "sp1-sdk",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "valence-account-utils",
  "valence-authorization-utils",
  "valence-clearing-queue-supervaults",
@@ -10669,9 +10630,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ opentelemetry-appender-log = "0.30.0"
 
 
 # valence-protocol
-valence-domain-clients               = { git = "https://github.com/timewave-computer/valence-domain-clients.git", rev = "885feb6" }
+valence-domain-clients               = "3.0.0"
 valence-authorization-utils          = { git = "https://github.com/timewave-computer/valence-protocol", rev = "6bc9ebb" }
 valence-processor-utils              = { git = "https://github.com/timewave-computer/valence-protocol", rev = "6bc9ebb" }
 valence-library-utils                = { git = "https://github.com/timewave-computer/valence-protocol", rev = "6bc9ebb" }

--- a/coprocessor-apps/clearing-queue/controller/src/lib.rs
+++ b/coprocessor-apps/clearing-queue/controller/src/lib.rs
@@ -21,7 +21,9 @@ const FN_SELECTOR: [u8; 4] = withdrawRequestsCall::SELECTOR;
 const WITHDRAWS_MAPPING_SLOT: u64 = 0xA;
 
 pub fn get_witnesses(args: Value) -> anyhow::Result<Vec<Witness>> {
-    let domain = args["domain"].as_str().ok_or(anyhow::anyhow!("args must include domain"))?;
+    let domain = args["domain"]
+        .as_str()
+        .ok_or(anyhow::anyhow!("args must include domain"))?;
 
     let block =
         abi::get_latest_block(domain)?.ok_or_else(|| anyhow::anyhow!("no valid domain block"))?;

--- a/coprocessor-apps/clearing-queue/controller/src/lib.rs
+++ b/coprocessor-apps/clearing-queue/controller/src/lib.rs
@@ -14,7 +14,6 @@ use valence_coprocessor_ethereum::{
 use valence_coprocessor_wasm::abi;
 
 const NETWORK: &str = "eth-mainnet";
-const DOMAIN: &str = "ethereum-electra-alpha";
 
 const FN_SELECTOR: [u8; 4] = withdrawRequestsCall::SELECTOR;
 
@@ -22,8 +21,10 @@ const FN_SELECTOR: [u8; 4] = withdrawRequestsCall::SELECTOR;
 const WITHDRAWS_MAPPING_SLOT: u64 = 0xA;
 
 pub fn get_witnesses(args: Value) -> anyhow::Result<Vec<Witness>> {
+    let domain = args["domain"].as_str().ok_or(anyhow::anyhow!("args must include domain"))?;
+
     let block =
-        abi::get_latest_block(DOMAIN)?.ok_or_else(|| anyhow::anyhow!("no valid domain block"))?;
+        abi::get_latest_block(domain)?.ok_or_else(|| anyhow::anyhow!("no valid domain block"))?;
 
     let block = format!("{:#x}", block.number);
 

--- a/strategies/btc_lst/strategist/src/phases/obligation_registration.rs
+++ b/strategies/btc_lst/strategist/src/phases/obligation_registration.rs
@@ -65,7 +65,10 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
+            let withdraw_id_json = json!({
+                "domain": "ethereum-electra-beta",
+                "withdraw_request_id": obligation_id
+            });
 
             // post the proof request to the coprocessor client & await
             info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");

--- a/strategies/btc_lst/strategist/src/phases/obligation_registration.rs
+++ b/strategies/btc_lst/strategist/src/phases/obligation_registration.rs
@@ -65,18 +65,18 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({
+            let proof_request_json = json!({
                 "domain": "ethereum-electra-beta",
                 "withdraw_request_id": obligation_id
             });
 
             // post the proof request to the coprocessor client & await
-            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {proof_request_json}");
             let vault_zkp_response = self
                 .coprocessor_client
                 .prove(
                     &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
-                    &withdraw_id_json,
+                    &proof_request_json,
                 )
                 .await?;
             info!(target: REGISTRATION_PHASE, "vault zkp resp: {vault_zkp_response:?}");

--- a/strategies/btc_lst/strategist/src/strategy_config.rs
+++ b/strategies/btc_lst/strategist/src/strategy_config.rs
@@ -101,6 +101,7 @@ impl Strategy {
             &cfg.ethereum.denoms.deposit_token.to_string(),
             EUREKA_COSMOS_HUB_CHAIN_ID,
             &cfg.gaia.deposit_denom,
+            false,
         );
 
         Ok(Self {

--- a/strategies/cctp_lend/strategist/src/phases/obligation_registration.rs
+++ b/strategies/cctp_lend/strategist/src/phases/obligation_registration.rs
@@ -57,18 +57,18 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({
+            let proof_request_json = json!({
                 "domain": "ethereum-electra-beta",
                 "withdraw_request_id": obligation_id
             });
 
             // post the proof request to the coprocessor client & await
-            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {proof_request_json}");
             let vault_zkp_response = self
                 .coprocessor_client
                 .prove(
                     &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
-                    &withdraw_id_json,
+                    &proof_request_json,
                 )
                 .await?;
             info!(target: REGISTRATION_PHASE, "vault zkp resp: {vault_zkp_response:?}");

--- a/strategies/cctp_lend/strategist/src/phases/obligation_registration.rs
+++ b/strategies/cctp_lend/strategist/src/phases/obligation_registration.rs
@@ -57,7 +57,10 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
+            let withdraw_id_json = json!({
+                "domain": "ethereum-electra-beta",
+                "withdraw_request_id": obligation_id
+            });
 
             // post the proof request to the coprocessor client & await
             info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");

--- a/strategies/lombard_btc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/lombard_btc/strategist/src/phases/obligation_registration.rs
@@ -65,17 +65,18 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({
+            let proof_request_json = json!({
                 "domain": "ethereum-electra-beta",
                 "withdraw_request_id": obligation_id
             });
+
             // post the proof request to the coprocessor client & await
-            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {proof_request_json}");
             let vault_zkp_response = self
                 .coprocessor_client
                 .prove(
                     &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
-                    &withdraw_id_json,
+                    &proof_request_json,
                 )
                 .await?;
             info!(target: REGISTRATION_PHASE, "vault zkp resp: {vault_zkp_response:?}");

--- a/strategies/lombard_btc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/lombard_btc/strategist/src/phases/obligation_registration.rs
@@ -65,8 +65,10 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
-
+            let withdraw_id_json = json!({
+                "domain": "ethereum-electra-beta",
+                "withdraw_request_id": obligation_id
+            });
             // post the proof request to the coprocessor client & await
             info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
             let vault_zkp_response = self

--- a/strategies/lombard_btc/strategist/src/strategy_config.rs
+++ b/strategies/lombard_btc/strategist/src/strategy_config.rs
@@ -112,6 +112,7 @@ impl Strategy {
             &cfg.ethereum.denoms.deposit_token.to_string(),
             EUREKA_COSMOS_HUB_CHAIN_ID,
             &cfg.gaia.deposit_denom,
+            false,
         );
 
         Ok(Self {

--- a/strategies/maxbtc_mint/strategist/src/phases/obligation_registration.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/obligation_registration.rs
@@ -65,7 +65,10 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
+            let withdraw_id_json = json!({
+                "domain": "ethereum-electra-beta",
+                "withdraw_request_id": obligation_id
+            });
 
             // post the proof request to the coprocessor client & await
             info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");

--- a/strategies/maxbtc_mint/strategist/src/phases/obligation_registration.rs
+++ b/strategies/maxbtc_mint/strategist/src/phases/obligation_registration.rs
@@ -65,18 +65,18 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({
+            let proof_request_json = json!({
                 "domain": "ethereum-electra-beta",
                 "withdraw_request_id": obligation_id
             });
 
             // post the proof request to the coprocessor client & await
-            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {proof_request_json}");
             let vault_zkp_response = self
                 .coprocessor_client
                 .prove(
                     &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
-                    &withdraw_id_json,
+                    &proof_request_json,
                 )
                 .await?;
             info!(target: REGISTRATION_PHASE, "vault zkp resp: {vault_zkp_response:?}");

--- a/strategies/maxbtc_mint/strategist/src/strategy_config.rs
+++ b/strategies/maxbtc_mint/strategist/src/strategy_config.rs
@@ -101,6 +101,7 @@ impl Strategy {
             &cfg.ethereum.denoms.deposit_token.to_string(),
             EUREKA_COSMOS_HUB_CHAIN_ID,
             &cfg.gaia.deposit_denom,
+            false,
         );
 
         Ok(Self {

--- a/strategies/usdc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/usdc/strategist/src/phases/obligation_registration.rs
@@ -57,18 +57,18 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({
+            let proof_request_json = json!({
                 "domain": "ethereum-electra-beta",
                 "withdraw_request_id": obligation_id
             });
 
             // post the proof request to the coprocessor client & await
-            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {proof_request_json}");
             let vault_zkp_response = self
                 .coprocessor_client
                 .prove(
                     &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
-                    &withdraw_id_json,
+                    &proof_request_json,
                 )
                 .await?;
             info!(target: REGISTRATION_PHASE, "vault zkp resp: {vault_zkp_response:?}");

--- a/strategies/usdc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/usdc/strategist/src/phases/obligation_registration.rs
@@ -57,7 +57,10 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation #{obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
+            let withdraw_id_json = json!({
+                "domain": "ethereum-electra-beta",
+                "withdraw_request_id": obligation_id
+            });
 
             // post the proof request to the coprocessor client & await
             info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");

--- a/strategies/wbtc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/wbtc/strategist/src/phases/obligation_registration.rs
@@ -66,7 +66,10 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation_id={obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({"withdraw_request_id": obligation_id});
+            let withdraw_id_json = json!({
+                "domain": "ethereum-electra-beta",
+                "withdraw_request_id": obligation_id
+            });
 
             // post the proof request to the coprocessor client & await
             info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");

--- a/strategies/wbtc/strategist/src/phases/obligation_registration.rs
+++ b/strategies/wbtc/strategist/src/phases/obligation_registration.rs
@@ -66,18 +66,18 @@ impl Strategy {
             info!(target: REGISTRATION_PHASE, "processing obligation_id={obligation_id}");
 
             // build the json input for coprocessor client
-            let withdraw_id_json = json!({
+            let proof_request_json = json!({
                 "domain": "ethereum-electra-beta",
                 "withdraw_request_id": obligation_id
             });
 
             // post the proof request to the coprocessor client & await
-            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {withdraw_id_json}");
+            info!(target: REGISTRATION_PHASE, "posting proof request to coprocessor client: {proof_request_json}");
             let vault_zkp_response = self
                 .coprocessor_client
                 .prove(
                     &self.cfg.neutron.coprocessor_app_ids.clearing_queue,
-                    &withdraw_id_json,
+                    &proof_request_json,
                 )
                 .await?;
 

--- a/strategies/wbtc/strategist/src/strategy_config.rs
+++ b/strategies/wbtc/strategist/src/strategy_config.rs
@@ -100,6 +100,7 @@ impl Strategy {
             &cfg.ethereum.denoms.deposit_token.to_string(),
             EUREKA_COSMOS_HUB_CHAIN_ID,
             &cfg.gaia.deposit_denom,
+            false,
         );
 
         Ok(Self {


### PR DESCRIPTION
# Description

- moves clearing queue `domain` to args
- bumps `valence-domain-clients` to 3.0.0
- updates strategists to include `domain` in the clearing queue proof request 